### PR TITLE
Teach challenge-first agent self-registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The catalogue is built item by item from the local API, SDK, CLI, and MCP source
 | `sendmux-cli`                   | Using the `sendmux` CLI from a terminal.                                                                |
 | `sendmux-mcp-setup`             | Connecting Sendmux MCP servers to an agent client.                                                      |
 | `sendmux-token-efficient-usage` | Choosing low-token Sendmux calls and avoiding wasteful reads.                                           |
-| `sendmux-email-for-agents`      | Giving an AI agent an inbox, self-registration flow, or email workflow, even when Sendmux is not named. |
+| `sendmux-email-for-agents`      | Giving an AI agent an inbox, challenge-first self-registration flow, or email workflow, even when Sendmux is not named. |
 
 ## Install Matrix
 

--- a/skills/sendmux-email-for-agents/SKILL.md
+++ b/skills/sendmux-email-for-agents/SKILL.md
@@ -16,7 +16,7 @@ Use this skill when the user describes the agent-email problem: an AI agent need
 | User problem                               | Route                                                                                                                                                       |
 | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | "Give my agent an email address"           | `sendmux-management` to create/inspect domain, mailbox, and mailbox key.                                                                                    |
-| "Let my agent register itself"             | Agent access: `POST /agent-auth/agent/identity`, token exchange, then owner invite through `POST /agent-auth/agent/identity/invite`.                        |
+| "Let my agent register itself"             | Agent access: read `/auth.md`, request a registration challenge, register with `proof_of_work`, exchange the assertion, then invite the owner.               |
 | "Connect my agent to its inbox"            | `sendmux-mcp-setup` for agent MCP, or `sendmux-getting-started` for first auth checks.                                                                      |
 | "Read, search, triage, label, sync, reply" | `sendmux-mailbox-agent` with an `smx_mbx_*` key or scoped `smx_agent_*` token.                                                                              |
 | "Send independent outbound notifications"  | `sendmux-send-email` with a send-capable `smx_mbx_*` key or owner-approved Sending-resource `smx_agent_*` token; batch when there is more than one message. |
@@ -32,11 +32,14 @@ If the task crosses setup and runtime, split it:
 
 For self-registration without a human-created key, use agent access instead:
 
-1. Create an anonymous identity with `POST /agent-auth/agent/identity`.
-2. Save the returned `claim_token`, then exchange the returned `identity_assertion` at `POST /agent-auth/oauth2/token`.
-3. Use the returned pre-claim `smx_agent_*` token for allowed Mailbox API work.
-4. Request the owner invite with `POST /agent-auth/agent/identity/invite`.
-5. After the owner accepts and approves sending in Sendmux, exchange `claim_token` with the claim grant for an app-resource or Sending-resource `smx_agent_*` token.
+1. Read `https://app.sendmux.ai/auth.md`.
+2. Send the intended anonymous registration body to `POST /agent-auth/agent/identity/challenge`.
+3. Solve the returned proof-of-work challenge.
+4. Create the anonymous identity with the same body plus `proof_of_work` at `POST /agent-auth/agent/identity`.
+5. Save the returned `claim_token`, then exchange the returned `identity_assertion` at `POST /agent-auth/oauth2/token`.
+6. Use the returned pre-claim `smx_agent_*` token for allowed Mailbox API work.
+7. Request the owner invite with `POST /agent-auth/agent/identity/invite`.
+8. After the owner accepts and approves sending in Sendmux, exchange `claim_token` with the claim grant for an app-resource or Sending-resource `smx_agent_*` token.
 
 ## Safety boundaries
 
@@ -48,6 +51,7 @@ For self-registration without a human-created key, use agent access instead:
 - Pre-claim `smx_agent_*` tokens include `mailbox.read` and `email.receive`, not `email.send`.
 - Owner invites are sent by Sendmux through the invite endpoint. Do not route them through the Sending API.
 - Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key.
+- Agent-auth `429` responses include retry timing; wait for `Retry-After` or `retry_after` before trying again.
 - Confirm destructive mailbox actions before delete, permanent delete, key revocation, suspend, or resume.
 
 ## Workflow patterns
@@ -73,13 +77,14 @@ Use when the user wants the agent to start without a human-created API key.
 Plan:
 
 1. Read discovery from `https://app.sendmux.ai/auth.md`.
-2. Create an anonymous identity at `/agent-auth/agent/identity`.
-3. Save the returned `claim_token`, then exchange `identity_assertion` at `/agent-auth/oauth2/token`.
-4. Use the pre-claim `smx_agent_*` token for allowed Mailbox API read/receive work.
-5. Request an owner invite at `/agent-auth/agent/identity/invite`.
-6. After owner approval, exchange `claim_token` at `/agent-auth/oauth2/token` with Sendmux's documented claim grant; request `resource=https://smtp.sendmux.ai/api/v1` before Sending API calls.
+2. Request a registration challenge at `/agent-auth/agent/identity/challenge` with the intended anonymous registration body.
+3. Solve the returned challenge and create the anonymous identity at `/agent-auth/agent/identity` with the same body plus `proof_of_work`.
+4. Save the returned `claim_token`, then exchange `identity_assertion` at `/agent-auth/oauth2/token`.
+5. Use the pre-claim `smx_agent_*` token for allowed Mailbox API read/receive work.
+6. Request an owner invite at `/agent-auth/agent/identity/invite`.
+7. After owner approval, exchange `claim_token` at `/agent-auth/oauth2/token` with Sendmux's documented claim grant; request `resource=https://smtp.sendmux.ai/api/v1` before Sending API calls.
 
-Do not say the pre-claim agent can send email. It cannot. After owner approval, a Sending-resource claim-grant `smx_agent_*` token can send from the assigned mailbox. Sendmux sends the owner invite email separately. Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key.
+Do not say the pre-claim agent can send email. It cannot. After owner approval, a Sending-resource claim-grant `smx_agent_*` token can send from the assigned mailbox. Sendmux sends the owner invite email separately. Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key. On `429`, wait for `Retry-After` or `retry_after`.
 
 ### Agent triage loop
 

--- a/skills/sendmux-email-for-agents/evals/evals.json
+++ b/skills/sendmux-email-for-agents/evals/evals.json
@@ -4,10 +4,10 @@
     {
       "id": 0,
       "prompt": "I am building an assistant that needs its own email address. It should receive client mail, find invoice messages, draft replies for a human to approve, and sometimes send outbound status notifications. What Sendmux workflow and skills should I use?",
-      "expected_output": "The answer routes setup to sendmux-management or agent access, runtime mailbox work to sendmux-mailbox-agent, notifications to sendmux-send-email with a send-capable smx_mbx_ key or owner-approved Sending-resource smx_agent_ token, MCP setup when appropriate, and token efficiency to sendmux-token-efficient-usage; it separates smx_root_ admin from smx_mbx_/smx_agent_ mailbox runtime and requires approval before sending drafts.",
+      "expected_output": "The answer routes setup to sendmux-management or challenge-first agent access, runtime mailbox work to sendmux-mailbox-agent, notifications to sendmux-send-email with a send-capable smx_mbx_ key or owner-approved Sending-resource smx_agent_ token, MCP setup when appropriate, and token efficiency to sendmux-token-efficient-usage; it separates smx_root_ admin from smx_mbx_/smx_agent_ mailbox runtime and requires approval before sending drafts.",
       "files": [],
       "expectations": [
-        "The output routes domain/mailbox/key setup to sendmux-management.",
+        "The output routes domain/mailbox/key setup to sendmux-management or challenge-first agent access.",
         "The output routes mailbox read/search/triage/reply work to sendmux-mailbox-agent.",
         "The output routes independent outbound notifications to sendmux-send-email.",
         "The output separates smx_root_ admin keys from smx_mbx_ or smx_agent_ runtime credentials.",
@@ -41,6 +41,22 @@
         "The output uses mailbox_count_messages, mailbox_search_message_snippets, or mailbox_batch_get_messages for invoice discovery.",
         "The output uses mailbox_batch_update_messages only after label confirmation.",
         "The output uses mailbox_send_message only after approval and includes idempotency."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "My agent has no Sendmux key. It wants to create its own inbox, read incoming mail, and invite me as the owner so I can later approve sending. What sequence should it follow?",
+      "expected_output": "The answer uses agent access: read /auth.md, request a registration challenge, solve it, register with proof_of_work, save claim_token, exchange identity_assertion for a pre-claim smx_agent_ token, use only read/receive mailbox access, invite the owner, wait for owner approval, then exchange the claim token for an app-resource or Sending-resource smx_agent_ token.",
+      "files": [],
+      "expectations": [
+        "The output starts from /auth.md.",
+        "The output requests /agent-auth/agent/identity/challenge before /agent-auth/agent/identity.",
+        "The output says registration includes proof_of_work.",
+        "The output saves claim_token and exchanges identity_assertion at /agent-auth/oauth2/token.",
+        "The output says pre-claim smx_agent_ cannot send.",
+        "The output invites the owner through /agent-auth/agent/identity/invite.",
+        "The output waits for owner approval before requesting a Sending-resource smx_agent_ token.",
+        "The output tells the agent to respect Retry-After or retry_after on 429."
       ]
     }
   ]

--- a/skills/sendmux-email-for-agents/evals/trigger-evals.json
+++ b/skills/sendmux-email-for-agents/evals/trigger-evals.json
@@ -20,6 +20,10 @@
     "should_trigger": true
   },
   {
+    "query": "Let my AI agent self-register an inbox and invite me as the owner.",
+    "should_trigger": true
+  },
+  {
     "query": "Install the Sendmux CLI and create profiles.",
     "should_trigger": false
   },

--- a/skills/sendmux-getting-started/SKILL.md
+++ b/skills/sendmux-getting-started/SKILL.md
@@ -25,7 +25,7 @@ Use this skill to get a user from "I have a Sendmux task" to the correct surface
 | Send email through the Sending API                                                      | Send-capable `smx_mbx_` or owner-approved Sending-resource `smx_agent_` | `sendmux-send-email` for real sends; this skill can verify package/API discovery first.                                  |
 | Read, search, sync, triage, or reply from one mailbox                                   | `smx_mbx_` or scoped `smx_agent_`                                       | Mailbox MCP, CLI, or SDK.                                                                                                |
 | Manage domains, mailboxes, mailbox keys, providers, webhooks, logs, billing, or metrics | `smx_root_`                                                             | Management MCP, CLI, or SDK.                                                                                             |
-| Let an agent register itself and invite its owner                                       | No existing key, then `smx_agent_`                                      | Agent access: `/auth.md`, `/agent-auth/agent/identity`, `/agent-auth/oauth2/token`, `/agent-auth/agent/identity/invite`. |
+| Let an agent register itself and invite its owner                                       | No existing key, then `smx_agent_`                                      | Agent access: `/auth.md`, `/agent-auth/agent/identity/challenge`, `/agent-auth/agent/identity`, `/agent-auth/oauth2/token`, `/agent-auth/agent/identity/invite`. |
 
 If the task mixes management and mailbox work, use separate keys and separate clients or profiles. Do not use a root key for mailbox-scoped examples.
 
@@ -94,13 +94,15 @@ This call resolves the mailbox behind the bearer token and should be the default
 Use this when the agent has no human-created key yet.
 
 1. Read `https://app.sendmux.ai/auth.md`.
-2. Create an anonymous identity with `POST /agent-auth/agent/identity`.
-3. Save the returned `claim_token`, then exchange the returned `identity_assertion` with `POST /agent-auth/oauth2/token`.
-4. Call `GET /mailbox/me` with the returned `smx_agent_` token.
-5. Request the owner invite with `POST /agent-auth/agent/identity/invite`.
-6. After the owner accepts and approves sending in Sendmux, exchange `claim_token` with the claim grant; request `resource=https://smtp.sendmux.ai/api/v1` before Sending API calls.
+2. Request a registration challenge with the intended anonymous registration body at `POST /agent-auth/agent/identity/challenge`.
+3. Solve the returned proof-of-work challenge.
+4. Create an anonymous identity with the same body plus `proof_of_work` at `POST /agent-auth/agent/identity`.
+5. Save the returned `claim_token`, then exchange the returned `identity_assertion` with `POST /agent-auth/oauth2/token`.
+6. Call `GET /mailbox/me` with the returned `smx_agent_` token.
+7. Request the owner invite with `POST /agent-auth/agent/identity/invite`.
+8. After the owner accepts and approves sending in Sendmux, exchange `claim_token` with the claim grant; request `resource=https://smtp.sendmux.ai/api/v1` before Sending API calls.
 
-Pre-claim `smx_agent_` tokens have `mailbox.read` and `email.receive`. They do not have `email.send`; owner-approved Sending-resource `smx_agent_` tokens can send from the assigned mailbox. Sendmux sends the owner invite through the invite endpoint. Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key.
+Pre-claim `smx_agent_` tokens have `mailbox.read` and `email.receive`. They do not have `email.send`; owner-approved Sending-resource `smx_agent_` tokens can send from the assigned mailbox. Sendmux sends the owner invite through the invite endpoint. Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key. If agent auth returns `429`, wait for `Retry-After` or `retry_after` before retrying.
 
 ### Root key, management work
 

--- a/skills/sendmux-getting-started/evals/evals.json
+++ b/skills/sendmux-getting-started/evals/evals.json
@@ -36,6 +36,22 @@
         "The output recommends SDKs for application code.",
         "The output does not claim MCP covers every Sendmux operation."
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "My coding agent has no Sendmux key. How does it register itself and invite me as the owner?",
+      "expected_output": "The answer starts from /auth.md, requests /agent-auth/agent/identity/challenge with the intended anonymous registration body, solves the challenge, registers with proof_of_work at /agent-auth/agent/identity, exchanges identity_assertion at /agent-auth/oauth2/token, uses the pre-claim smx_agent_ token for mailbox read/receive only, sends the owner invite, and waits for owner approval before requesting a send-capable claim-grant token.",
+      "files": [],
+      "expectations": [
+        "The output starts from /auth.md.",
+        "The output requests /agent-auth/agent/identity/challenge before registration.",
+        "The output says to register with proof_of_work.",
+        "The output exchanges identity_assertion at /agent-auth/oauth2/token.",
+        "The output says pre-claim smx_agent_ tokens do not have email.send.",
+        "The output invites the owner with /agent-auth/agent/identity/invite.",
+        "The output waits for owner approval before sending access.",
+        "The output uses Retry-After or retry_after for 429 retries."
+      ]
     }
   ]
 }

--- a/skills/sendmux-getting-started/evals/trigger-evals.json
+++ b/skills/sendmux-getting-started/evals/trigger-evals.json
@@ -12,6 +12,10 @@
     "should_trigger": true
   },
   {
+    "query": "Let my agent register itself with Sendmux and invite me as the owner.",
+    "should_trigger": true
+  },
+  {
     "query": "Write a reusable table component for a dashboard.",
     "should_trigger": false
   },


### PR DESCRIPTION
## Summary
- update Sendmux agent skills to use challenge-first anonymous registration
- document retry handling for rate-limited auth flows
- add eval coverage for challenge and owner invite flows

## Validation
- jq empty on changed eval files
- skill drift check against updated docs
- public leak scan
- git diff --check