### PR TITLE
feat(skills): add Sendmux attachment workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The catalogue is built item by item from the local API, SDK, CLI, and MCP source
 | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `sendmux-getting-started`       | Choosing a Sendmux surface, setting up auth, or making a first verified call.                           |
 | `sendmux-send-email`            | Sending single or batch transactional email.                                                            |
+| `sendmux-attachments`           | Uploading, downloading, or sending attachments without wasting context on base64.                       |
 | `sendmux-mailbox-agent`         | Reading, triaging, replying, or syncing one mailbox.                                                    |
 | `sendmux-management`            | Managing domains, mailboxes, sending accounts, webhooks, billing, and logs.                             |
 | `sendmux-cli`                   | Using the `sendmux` CLI from a terminal.                                                                |

--- a/scripts/check-skill-drift.mjs
+++ b/scripts/check-skill-drift.mjs
@@ -21,6 +21,7 @@ const sendingOpenApi =
 
 const expectedSkills = [
   "sendmux-cli",
+  "sendmux-attachments",
   "sendmux-email-for-agents",
   "sendmux-getting-started",
   "sendmux-mailbox-agent",
@@ -36,6 +37,9 @@ const requiredSendingPaths = [
 ];
 
 const requiredMailboxPaths = [
+  ["post", "/mailbox/attachments:upload"],
+  ["get", "/mailbox/messages/{message_id}/attachments/{attachment_id}"],
+  ["post", "/mailbox/attachment-uploads"],
   ["post", "/mailbox/messages:batch-get"],
   ["post", "/mailbox/messages:batch-update"],
   ["post", "/mailbox/messages:batch-delete"],
@@ -54,6 +58,9 @@ const requiredMcpTools = [
   "mailbox_batch_get_messages",
   "mailbox_get_changes",
   "mailbox_send_message",
+  "mailbox_get_attachment",
+  "mailbox_upload_attachment",
+  "mailbox_wait_for_message",
   "management_create_domain",
   "management_create_mailbox",
   "management_create_mailbox_key",
@@ -126,6 +133,9 @@ const requiredCorpusTokens = [
   ["mailbox snippets MCP tool", /mailbox_search_message_snippets/],
   ["mailbox batch-get MCP tool", /mailbox_batch_get_messages/],
   ["mailbox changes MCP tool", /mailbox_get_changes/],
+  ["attachment skill", /sendmux-attachments/],
+  ["mailbox upload attachment MCP tool", /mailbox_upload_attachment/],
+  ["mailbox attachment metadata MCP tool", /mailbox_get_attachment/],
   ["management create domain MCP tool", /management_create_domain/],
   ["management create mailbox MCP tool", /management_create_mailbox/],
   ["management create mailbox key MCP tool", /management_create_mailbox_key/],

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -16,6 +16,7 @@
       "description": "Skills for sending email, reading mailboxes, and giving agents email workflows.",
       "skills": [
         "sendmux-send-email",
+        "sendmux-attachments",
         "sendmux-mailbox-agent",
         "sendmux-email-for-agents"
       ]

--- a/skills/sendmux-attachments/SKILL.md
+++ b/skills/sendmux-attachments/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: sendmux-attachments
+description: Use Sendmux attachment workflows without wasting model context on base64. Use when uploading, downloading, reading, forwarding, or sending email attachments through Sendmux MCP, CLI, SDKs, or direct HTTP, especially when choosing file_path vs presigned upload URL vs inline base64, fetching short-lived download_url links, or attaching local files to outbound mail.
+license: Apache-2.0
+metadata:
+  author: sendmux
+  version: "1.0"
+---
+
+# Sendmux attachments
+
+Use this skill whenever a Sendmux task involves attachment bytes.
+
+## Core rule
+
+Do not pipe real files through model context as base64 unless the file is tiny and agent-authored. Prefer paths or signed URLs.
+
+| Mode | Use when | Token cost | Limit |
+| --- | --- | ---: | --- |
+| Local `file_path` | Local stdio MCP can read the user-shared file root. | tiny | Mailbox cap: 7,500,000 bytes per attachment. |
+| Presigned upload URL | Hosted MCP, shell-capable agents, or large local files. | tiny | Mailbox cap: 7,500,000 bytes; exact size is signed. |
+| CLI `--attach` / SDK file helpers | Terminal or application code can read the file. | tiny | Mailbox cap for mailbox sends; Sending API request limit for Sending sends. |
+| Inline base64 | Small generated text/files only. | high | MCP inline cap is 32 KiB decoded. |
+
+Approximate base64 cost: 25 KB becomes about 11K generated tokens; 1 MB is impractical. A file path is usually under 100 tokens.
+
+## Security model
+
+- A caller must authenticate to mint upload URLs or upload directly.
+- The later presigned `PUT` has no `Authorization` header, but it only works with the unguessable short-lived signed URL and exact headers returned by Sendmux.
+- Do not invent file-type allow-lists. Set the best `Content-Type`; let Sendmux return the real validation error if a file is rejected.
+- For presigned `PUT`, send the exact `Content-Type` and `Content-Length` returned with the URL.
+- Do not try to bypass upload size caps. For mailbox uploads, split or externally host files over 7,500,000 bytes.
+- For downloads, use the `download_url` in attachment metadata promptly. If it expires, fetch the message or attachment metadata again.
+
+## MCP
+
+Use `mailbox_upload_attachment` before `mailbox_send_message`.
+
+Local stdio, cheapest path:
+
+```text
+mailbox_upload_attachment
+filename: report.pdf
+content_type: application/pdf
+file_path: /absolute/path/report.pdf
+```
+
+The file path must be inside a filesystem root shared by the MCP client. Hosted MCP rejects `file_path`.
+
+Hosted or shell-capable path:
+
+```text
+mailbox_upload_attachment
+filename: report.pdf
+content_type: application/pdf
+size_bytes: 5242880
+presign_upload_url: true
+```
+
+Then upload without an API key:
+
+```bash
+curl -X PUT "$UPLOAD_URL" \
+  -H "Content-Type: application/pdf" \
+  -H "Content-Length: 5242880" \
+  --data-binary @./report.pdf
+```
+
+Use the returned `blob_id` in `mailbox_send_message`:
+
+```json
+{
+  "attachments": [
+    {
+      "blob_id": "blob_...",
+      "filename": "report.pdf",
+      "content_type": "application/pdf"
+    }
+  ]
+}
+```
+
+For tiny generated content only, use `content_base64`. If the tool rejects size, switch to `file_path`, presigned upload, CLI, or SDK file helpers.
+
+To read inbound attachments, call `mailbox_get_attachment` or fetch message metadata, then fetch `download_url` promptly. Do not construct attachment URLs manually.
+
+## CLI
+
+Mailbox send with a local attachment in one command:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:send-message \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --attach ./report.pdf \
+  --body '{
+    "to": [{ "email": "user@example.com", "name": null }],
+    "subject": "Report",
+    "text_body": "Attached."
+  }' \
+  --json
+```
+
+Sending API with a local attachment:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:send \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --attach ./report.pdf \
+  --body-file ./email.json \
+  --json
+```
+
+Presigned mailbox upload from a local file:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:upload-attachment \
+  --file ./report.pdf \
+  --via-presigned \
+  --json
+```
+
+Mint only:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:create-attachment-upload \
+  --file ./report.pdf \
+  --json
+```
+
+Override MIME type with `--content-type` only when inference is wrong.
+
+## TypeScript
+
+Node file helpers live under Node subpaths so browser bundles stay clean.
+
+Mailbox:
+
+```ts
+import { createMailboxClient } from "@sendmux/mailbox";
+import { sendMailboxMessageWithFiles } from "@sendmux/mailbox/node";
+
+const client = createMailboxClient({ apiKey: process.env.SENDMUX_API_KEY! });
+
+await sendMailboxMessageWithFiles({
+  client,
+  files: ["./report.pdf"],
+  headers: { "Idempotency-Key": idempotencyKey },
+  body: {
+    to: [{ email: "user@example.com", name: null }],
+    subject: "Report",
+    text_body: "Attached.",
+  },
+});
+```
+
+Sending API:
+
+```ts
+import { createSendingClient } from "@sendmux/sending";
+import { sendEmailWithFiles } from "@sendmux/sending/node";
+
+const client = createSendingClient({ apiKey: process.env.SENDMUX_API_KEY! });
+
+await sendEmailWithFiles({
+  client,
+  files: ["./report.pdf"],
+  headers: { "Idempotency-Key": idempotencyKey },
+  body: {
+    from: { email: "sender@example.com" },
+    to: { email: "user@example.com" },
+    subject: "Report",
+    html_body: "<p>Attached.</p>",
+  },
+});
+```
+
+The combined package also exposes `@sendmux/sdk/node`.
+
+## Python
+
+Mailbox:
+
+```python
+from sendmux_mailbox import create_mailbox_client, send_mailbox_message_with_files
+
+client = create_mailbox_client(api_key=api_key)
+
+send_mailbox_message_with_files(
+    client,
+    files=["./report.pdf"],
+    body={
+        "to": [{"email": "user@example.com", "name": None}],
+        "subject": "Report",
+        "text_body": "Attached.",
+    },
+    idempotency_key=idempotency_key,
+)
+```
+
+Sending API:
+
+```python
+from sendmux_sending import create_sending_client, send_email_with_files
+
+client = create_sending_client(api_key=api_key)
+
+send_email_with_files(
+    client,
+    files=["./report.pdf"],
+    body={
+        "from": {"email": "sender@example.com"},
+        "to": {"email": "user@example.com"},
+        "subject": "Report",
+        "html_body": "<p>Attached.</p>",
+    },
+    idempotency_key=idempotency_key,
+)
+```
+
+## Routing
+
+- Sending content and recipient approval: `sendmux-send-email`.
+- Mailbox search, triage, reply flow: `sendmux-mailbox-agent`.
+- Exact terminal command mechanics: `sendmux-cli`.
+- MCP installation or hosted/local setup: `sendmux-mcp-setup`.
+- General token-efficiency decisions: `sendmux-token-efficient-usage`.

--- a/skills/sendmux-attachments/agents/openai.yaml
+++ b/skills/sendmux-attachments/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sendmux Attachments"
+  short_description: "Use Sendmux attachments efficiently."
+  default_prompt: "Use $sendmux-attachments to upload, download, or send Sendmux email attachments without wasting context on base64."

--- a/skills/sendmux-attachments/evals/evals.json
+++ b/skills/sendmux-attachments/evals/evals.json
@@ -1,0 +1,43 @@
+{
+  "skill_name": "sendmux-attachments",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "A local MCP agent needs to send a 5 MB PDF through Sendmux Mailbox. What should it do?",
+      "expected_output": "The answer chooses mailbox_upload_attachment with file_path for local stdio MCP, says the path must be inside a shared root, avoids base64, then uses the returned blob_id in mailbox_send_message.",
+      "files": [],
+      "expectations": [
+        "The output chooses mailbox_upload_attachment with file_path.",
+        "The output says file_path is local stdio only or must be inside a shared root.",
+        "The output avoids inline base64 for a 5 MB file.",
+        "The output uses the returned blob_id in mailbox_send_message."
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "A hosted MCP agent with shell access needs to attach ./report.pdf without exposing an API key in curl. What Sendmux flow should it use?",
+      "expected_output": "The answer mints a presigned upload URL with mailbox_upload_attachment presign_upload_url true, then uses curl PUT with exact Content-Type and Content-Length and no Authorization header, then sends with the returned blob_id.",
+      "files": [],
+      "expectations": [
+        "The output uses presign_upload_url true.",
+        "The output includes size_bytes, filename, and content_type.",
+        "The output uses curl PUT with exact Content-Type and Content-Length.",
+        "The output says the PUT does not include an Authorization header.",
+        "The output sends with the returned blob_id."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Show TypeScript and Python Sendmux helpers for sending an email with a local file attachment without manual base64 encoding.",
+      "expected_output": "The answer uses @sendmux/mailbox/node or @sendmux/sending/node helpers in TypeScript and sendmux_mailbox or sendmux_sending file helpers in Python, with file paths rather than hand-written base64.",
+      "files": [],
+      "expectations": [
+        "The output names @sendmux/mailbox/node or @sendmux/sending/node.",
+        "The output names sendMailboxMessageWithFiles or sendEmailWithFiles.",
+        "The output names Python send_mailbox_message_with_files or send_email_with_files.",
+        "The output passes a file path.",
+        "The output avoids manual base64 encoding."
+      ]
+    }
+  ]
+}

--- a/skills/sendmux-attachments/evals/trigger-evals.json
+++ b/skills/sendmux-attachments/evals/trigger-evals.json
@@ -1,0 +1,22 @@
+[
+  {
+    "query": "Attach a local PDF to a Sendmux email without base64 in context.",
+    "should_trigger": true
+  },
+  {
+    "query": "How should a hosted MCP agent upload a Sendmux attachment with curl?",
+    "should_trigger": true
+  },
+  {
+    "query": "Fetch a Sendmux attachment download_url from mailbox metadata.",
+    "should_trigger": true
+  },
+  {
+    "query": "Search unread Sendmux messages for invoices.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a Sendmux domain and mailbox key.",
+    "should_trigger": false
+  }
+]

--- a/skills/sendmux-cli/SKILL.md
+++ b/skills/sendmux-cli/SKILL.md
@@ -74,8 +74,8 @@ The CLI exposes generated operation commands:
 
 | Surface    | Count | Examples                                                                                                                                                   |
 | ---------- | ----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Management |    52 | `management:domains:list`, `management:create-domain`, `management:create-mailbox`, `management:get-spend-summary`, `management:create-webhook`            |
-| Mailbox    |    40 | `mailbox:search-message-snippets`, `mailbox:batch-get-messages`, `mailbox:query-message-changes`, `mailbox:send-message`, `mailbox:list-granted-mailboxes` |
+| Management |    53 | `management:domains:list`, `management:create-domain`, `management:create-mailbox`, `management:get-spend-summary`, `management:create-webhook`            |
+| Mailbox    |    41 | `mailbox:search-message-snippets`, `mailbox:batch-get-messages`, `mailbox:query-message-changes`, `mailbox:send-message`, `mailbox:list-granted-mailboxes` |
 | Sending    |     3 | `sending:get-open-api-spec`, `sending:send`, `sending:send:batch`                                                                                          |
 | Profiles   |     3 | `profiles:list`, `profiles:set`, `profiles:show`                                                                                                           |
 
@@ -98,6 +98,10 @@ Operation commands share these flags:
 | `--profile`, `-p`     | Select a local profile.                                                    |
 | `--body`              | Inline JSON request body, or text bytes for byte-oriented operations.      |
 | `--body-file`         | Read a JSON request body or byte payload from a file.                      |
+| `--attach`            | Attach a local file to supported send commands. Repeat for multiple files. |
+| `--file`              | Read a local file for attachment upload commands.                          |
+| `--via-presigned`     | Upload a `--file` through a short-lived signed URL instead of API bytes.   |
+| `--content-type`      | Override inferred MIME type for `--attach` or `--file`.                    |
 | `--path name=value`   | Path parameters. Repeat for multiple path params.                          |
 | `--query name=value`  | Query parameters. Repeat for filters and pagination.                       |
 | `--header name=value` | Headers accepted by the operation. Repeat for multiple headers.            |
@@ -109,6 +113,8 @@ Operation commands share these flags:
 `--path`, `--query`, and `--header` require `name=value`. Booleans use `true` or `false`. Repeat an array-valued parameter rather than comma-joining it.
 
 Pass either `--body` or `--body-file`, not both.
+
+Use `sendmux-attachments` for attachment-heavy flows and size/token trade-offs.
 
 ## Examples
 
@@ -165,6 +171,29 @@ sendmux sending:send:batch \
   --json
 ```
 
+Send a mailbox message with a local attachment:
+
+```bash
+sendmux mailbox:send-message \
+  --profile mailbox \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --attach ./report.pdf \
+  --body '{"to":[{"email":"user@example.com","name":null}],"subject":"Report","text_body":"Attached."}' \
+  --json
+```
+
+Mailbox attachment upload commands share the 7,500,000 byte per-attachment cap. For larger files, split the file or host it externally and send a link.
+
+Upload a mailbox attachment by presigned URL:
+
+```bash
+sendmux mailbox:upload-attachment \
+  --profile mailbox \
+  --file ./report.pdf \
+  --via-presigned \
+  --json
+```
+
 Poll one unchanged-safe delivery log:
 
 ```bash
@@ -179,6 +208,7 @@ sendmux management:get-email-log \
 
 - First setup/auth check: `sendmux-getting-started`.
 - Sending strategy and body shape: `sendmux-send-email`.
+- Attachment file paths and presigned upload/download: `sendmux-attachments`.
 - Mailbox read, search, sync, triage, or reply: `sendmux-mailbox-agent`.
 - Account-level management strategy: `sendmux-management`.
 - MCP connection setup: `sendmux-mcp-setup`.

--- a/skills/sendmux-email-for-agents/SKILL.md
+++ b/skills/sendmux-email-for-agents/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the user describes the agent-email problem: an AI agent need
 | "Connect my agent to its inbox"            | `sendmux-mcp-setup` for agent MCP, or `sendmux-getting-started` for first auth checks.                                                                      |
 | "Read, search, triage, label, sync, reply" | `sendmux-mailbox-agent` with an `smx_mbx_*` key or scoped `smx_agent_*` token.                                                                              |
 | "Send independent outbound notifications"  | `sendmux-send-email` with a send-capable `smx_mbx_*` key or owner-approved Sending-resource `smx_agent_*` token; batch when there is more than one message. |
+| "Upload, download, or forward attachments" | `sendmux-attachments` for `file_path`, presigned upload URLs, CLI `--attach`, SDK file helpers, and short-lived download URLs.                              |
 | "Build this into an app or worker"         | SDK path from the task skill; use `sendmux-token-efficient-usage` for call minimisation.                                                                    |
 | "Show terminal commands"                   | `sendmux-cli`.                                                                                                                                              |
 
@@ -52,6 +53,7 @@ For self-registration without a human-created key, use agent access instead:
 - Keep the `identity_assertion` or pre-claim `smx_agent_*` token available until the owner invite returns `202`. If both are lost before the invite succeeds, register a fresh identity and invite immediately.
 - Do not poll the claim-token grant before the owner invite returns `202`; after `202`, polling with `claim_token` is the wait-for-approval path. `claim_token` cannot create the owner invite.
 - Do not send email until the user has supplied or confirmed the recipient, subject, body, and attachments.
+- Do not place real attachment bytes or long base64 in chat. Use `sendmux-attachments` so local files move by path, presigned URL, CLI, or SDK helper. Mailbox upload modes cap each attachment at 7,500,000 bytes.
 - Treat "draft for approval" as a draft. Ask for explicit approval before calling `mailbox_send_message`, `sending_send_email`, or `sending_send_email_batch`.
 - Use separate scopes: `smx_root_*` for provisioning/admin, send-capable `smx_mbx_*` keys or owner-approved Sending-resource `smx_agent_*` tokens for Sending, `smx_mbx_*` keys for normal Mailbox runtime, and `smx_agent_*` only for the scopes it was issued with.
 - Do not use a root key inside an agent that only needs mailbox read/send work.
@@ -149,7 +151,8 @@ This is a router and architecture skill. Hand detailed implementation to the tas
 
 - `sendmux-management`: domains, mailbox provisioning, mailbox keys, account admin, webhooks, billing, logs.
 - `sendmux-mailbox-agent`: mailbox read/search/sync/triage/reply.
-- `sendmux-send-email`: send bodies, attachments, batch send, HTTP-vs-SMTP send choice.
+- `sendmux-send-email`: send bodies, batch send, HTTP-vs-SMTP send choice.
+- `sendmux-attachments`: upload/download attachments without wasting context on base64.
 - `sendmux-mcp-setup`: client configuration and hosted/local MCP.
 - `sendmux-cli`: exact terminal commands and flags.
 - `sendmux-token-efficient-usage`: cheapest-call doctrine across surfaces.

--- a/skills/sendmux-mailbox-agent/SKILL.md
+++ b/skills/sendmux-mailbox-agent/SKILL.md
@@ -31,6 +31,7 @@ Use this skill for mailbox-scoped workflows with an `smx_mbx_` key or scoped `sm
 | Mark, flag, or label many messages | `mailbox_batch_update_messages`, CLI `mailbox:batch-update-messages`, SDK `mailboxBatchUpdateMessages`.       |
 | Delete many messages               | `mailbox_batch_delete_messages`, CLI `mailbox:batch-delete-messages`, SDK `mailboxBatchDeleteMessages`.       |
 | Reply/send from this mailbox       | `mailbox_send_message`, CLI `mailbox:send-message`, SDK `mailboxSendMessage`.                                 |
+| Upload/read attachments            | `mailbox_upload_attachment`, `mailbox_get_attachment`, and `sendmux-attachments` for zero-context files.       |
 | Threads                            | `mailbox_list_threads`, `mailbox_get_thread`, `mailbox_list_thread_messages`.                                 |
 | Folders                            | `mailbox_list_folders`; inspect folders before filing or moving messages.                                     |
 | Broad sync                         | `mailbox_get_changes`, CLI `mailbox:get-changes`, SDK `mailboxGetChanges`.                                    |
@@ -168,17 +169,18 @@ SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:send-message \
 
 Mailbox send uses `to` as an array. `subject` and `to` are required. `from` is optional when sending from the authenticated mailbox identity.
 
-Attachments may be inline small files:
+For attachments, route to `sendmux-attachments`.
 
-```json
-{
-  "filename": "report.pdf",
-  "content_type": "application/pdf",
-  "content": "<<base64-content>>"
-}
-```
+Prefer zero-context file flows:
 
-or uploaded blobs:
+- Local MCP: `mailbox_upload_attachment` with `file_path`, then send with the returned `blob_id`.
+- Hosted or shell-capable MCP: mint a presigned upload URL, `PUT` the file without an API key, then send with the returned `blob_id`.
+- CLI: `sendmux mailbox:send-message --attach ./report.pdf`.
+- SDK: use the Node or Python file helpers.
+
+Mailbox upload paths share a 7,500,000 byte per-attachment cap. For larger files, split them or send a link to externally hosted content.
+
+Inline base64 is only for tiny generated files. If you already have a blob, send it as:
 
 ```json
 {
@@ -246,6 +248,7 @@ Store the returned new state token. Follow `has_more` with the same filters when
 
 - First setup/auth check: `sendmux-getting-started`.
 - Independent outbound sending or batch sends: `sendmux-send-email`.
+- Attachment upload/download mechanics: `sendmux-attachments`.
 - Domain/mailbox/key creation and mailbox admin: `sendmux-management`.
 - CLI command details: `sendmux-cli`.
 - Cheapest-call doctrine: `sendmux-token-efficient-usage`.

--- a/skills/sendmux-mcp-setup/SKILL.md
+++ b/skills/sendmux-mcp-setup/SKILL.md
@@ -49,11 +49,17 @@ Console scripts:
 
 | Surface    | Key                                                                     | Tool count | Example tools                                                                                                                                         |
 | ---------- | ----------------------------------------------------------------------- | ---------: | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Mailbox    | `smx_mbx_` or scoped `smx_agent_`                                       |         21 | `mailbox_list_granted_mailboxes`, `mailbox_search_message_snippets`, `mailbox_batch_get_messages`, `mailbox_get_changes`, `mailbox_send_message`      |
+| Mailbox    | `smx_mbx_` or scoped `smx_agent_`                                       |         24 | `mailbox_list_granted_mailboxes`, `mailbox_search_message_snippets`, `mailbox_get_attachment`, `mailbox_upload_attachment`, `mailbox_wait_for_message` |
 | Management | `smx_root_`                                                             |         20 | `management_create_domain`, `management_create_mailbox`, `management_create_mailbox_key`, `management_get_spend_summary`, `management_create_webhook` |
 | Sending    | Send-capable `smx_mbx_` or owner-approved Sending-resource `smx_agent_` |          2 | `sending_send_email`, `sending_send_email_batch`                                                                                                      |
 
 For multi-mailbox grants, call `mailbox_list_granted_mailboxes` first and pass the returned `mailbox_id` to mailbox tools when targeting a mailbox.
+
+Attachment upload mode depends on transport:
+
+- Local stdio can use `mailbox_upload_attachment` with `file_path` when the file is inside a client-shared filesystem root.
+- Hosted MCP cannot read local paths. Use `presign_upload_url=true`, upload with shell `curl`, then send with the returned `blob_id`.
+- Use `content_base64` only for tiny generated files. Mailbox `file_path` and presigned upload modes cap each attachment at 7,500,000 bytes; MCP inline base64 caps at 32 KiB decoded. See `sendmux-attachments`.
 
 ## Local Servers
 
@@ -384,6 +390,7 @@ After adding the server:
 - First Sendmux API setup or first call: `sendmux-getting-started`.
 - Sending body shape or send strategy: `sendmux-send-email`.
 - Mailbox read, search, sync, triage, or reply: `sendmux-mailbox-agent`.
+- Attachment file paths, presigned uploads, and download URLs: `sendmux-attachments`.
 - Account-level management strategy: `sendmux-management`.
 - Terminal command mechanics: `sendmux-cli`.
 - Cheapest-call doctrine: `sendmux-token-efficient-usage`.

--- a/skills/sendmux-send-email/SKILL.md
+++ b/skills/sendmux-send-email/SKILL.md
@@ -55,7 +55,9 @@ Useful optional fields:
 - `reply_to`: one address object.
 - `return_path`: envelope sender for bounce handling.
 - `custom_headers`: custom `X-*` headers.
-- `attachments`: up to 10 items, each with `filename` and base64 `content`; optional `type`; `encoding` is `base64`.
+- `attachments`: up to 10 items, each with `filename` and base64 `content`; optional `type`; `encoding` is `base64`; total request body must stay within the Sending API limit.
+
+For real local files, do not ask the model to produce base64. Route attachment-heavy work to `sendmux-attachments`; use CLI `--attach`, SDK file helpers, or mailbox upload-to-`blob_id` first. Mailbox upload-to-`blob_id` caps each attachment at 7,500,000 bytes.
 
 Batch send body:
 
@@ -93,7 +95,7 @@ Use MCP when the user's agent already has the Sending server connected:
 - One message: `sending_send_email`.
 - Multiple messages: `sending_send_email_batch`.
 
-Include an idempotency key when the client exposes the header parameter. If the MCP client does not expose headers clearly, use CLI, SDK, or direct HTTP for retry-sensitive sends.
+Include an idempotency key when the client exposes the header parameter. If the MCP client does not expose headers clearly, use CLI, SDK, or direct HTTP for retry-sensitive sends. For attachments through MCP, use `sendmux-attachments` so the agent chooses `file_path`, presigned upload, or tiny inline base64 correctly.
 
 ## CLI
 
@@ -121,7 +123,7 @@ SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:send:batch \
   --json
 ```
 
-Use `--body-file` for attachments or larger JSON payloads to avoid shell escaping mistakes.
+Use `--attach ./file.pdf` for local files. Use `--body-file` for larger JSON payloads or already-prepared Sending API attachment objects.
 
 ## TypeScript SDK
 
@@ -206,6 +208,7 @@ Handle these errors deliberately:
 ## Routing
 
 - Setup/auth first call: `sendmux-getting-started`.
+- Attachment file paths, presigned upload URLs, and download URLs: `sendmux-attachments`.
 - Mailbox-centred replies: `sendmux-mailbox-agent`.
 - CLI-only details: `sendmux-cli`.
 - Cheapest-call decisions: `sendmux-token-efficient-usage`.

--- a/skills/sendmux-token-efficient-usage/SKILL.md
+++ b/skills/sendmux-token-efficient-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sendmux-token-efficient-usage
-description: "Choose the cheapest correct Sendmux surface and call. Use whenever a Sendmux task could be done through MCP, the sendmux CLI, an SDK, or direct HTTP and the user needs low-token, low-round-trip usage: batch sends, mailbox search/count/batch reads, sync deltas, cursor pagination, ETags, conditional requests, idempotency keys, or avoiding broad mailbox/log fetches."
+description: "Choose the cheapest correct Sendmux surface and call. Use whenever a Sendmux task could be done through MCP, the sendmux CLI, an SDK, or direct HTTP and the user needs low-token, low-round-trip usage: batch sends, mailbox search/count/batch reads, sync deltas, cursor pagination, ETags, conditional requests, idempotency keys, attachment file transfer, or avoiding broad mailbox/log fetches."
 license: Apache-2.0
 metadata:
   author: sendmux
@@ -18,6 +18,7 @@ Use this skill to choose the lowest-cost Sendmux route that still answers the ta
 - Use scoped `smx_agent_*` only for the calls its scopes and resource allow. Pre-claim agent tokens cannot send.
 - Use `smx_root_*` for Management calls.
 - Do not default to MCP for every task. MCP is best when the required tool is curated; CLI and SDK cover broader surfaces.
+- Do not pipe real attachments through model context as base64. Route attachment transfer to `sendmux-attachments`; prefer `file_path`, presigned URLs, CLI `--attach`, or SDK file helpers. Mailbox uploads cap each attachment at 7,500,000 bytes; MCP inline base64 caps at 32 KiB decoded.
 - Do not read full mailbox bodies, every message, or every log row unless the user asks for full content and narrower calls cannot answer.
 
 ## Surface choice
@@ -36,6 +37,7 @@ Use this skill to choose the lowest-cost Sendmux route that still answers the ta
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | Send one outbound email         | `sending_send_email`, CLI `sending:send`, SDK `sendingSendEmail`; include `Idempotency-Key`.                                           |
 | Send multiple outbound emails   | `sending_send_email_batch`, CLI `sending:send:batch`, SDK `sendingSendEmailBatch`; do not loop single sends.                           |
+| Send or read attachments        | `sendmux-attachments`; use `file_path`, presigned upload/download URLs, CLI `--attach`, or SDK file helpers instead of inline base64.   |
 | Count matching mailbox messages | `mailbox_count_messages`, CLI `mailbox:count-messages`, SDK `mailboxCountMessages`.                                                    |
 | Search mailbox text             | `mailbox_search_message_snippets`, CLI `mailbox:search-message-snippets`, SDK `mailboxSearchMessageSnippets`; then fetch selected IDs. |
 | Read several known messages     | `mailbox_batch_get_messages`, CLI `mailbox:batch-get-messages`, SDK `mailboxBatchGetMessages`.                                         |
@@ -140,6 +142,8 @@ Store the returned state token. Continue with the same filters only while `has_m
 - Prefer summary or metrics endpoints before log lists.
 - Use `If-None-Match` for repeated detail reads that previously returned an `ETag`.
 - Use `If-Match` for updates when the prior read returned an `ETag`.
+- For inbound attachments, fetch metadata and use the short-lived `download_url`; if it expires, re-fetch metadata instead of building URLs manually.
+- For outbound attachments, a file path or presigned URL is usually under 100 tokens, while base64 can burn thousands of tokens and corrupt large files.
 
 CLI conditional examples:
 
@@ -188,7 +192,8 @@ When retrying application code, prefer SDK retry helpers only for safe reads or 
 ## Routing
 
 - Setup, key scopes, first call: `sendmux-getting-started`.
-- Email send bodies, attachments, SMTP-vs-HTTP choice: `sendmux-send-email`.
+- Email send bodies and SMTP-vs-HTTP choice: `sendmux-send-email`.
+- Attachment upload/download mechanics: `sendmux-attachments`.
 - Mailbox read/search/sync/triage/reply details: `sendmux-mailbox-agent`.
 - Management domains, mailboxes, webhooks, billing, logs: `sendmux-management`.
 - CLI syntax and profiles: `sendmux-cli`.


### PR DESCRIPTION
## Summary
- Add a dedicated sendmux-attachments skill covering file_path, presigned upload, inline base64, and presigned download workflows.
- Update existing Sendmux skills to reference the zero-context attachment paths and current size caps.
- Regenerate the skills catalog/dist output.

## Verification
- SENDMUX_DOCS=/Users/rj/Desktop/GIT-REPOS/sendmux-docs SENDMUX_SDK=/Users/rj/Desktop/GIT-REPOS/sendmux-sdk-attachments-first-class node scripts/check-skill-drift.mjs
- Python frontmatter parse for all skills/sendmux-*/SKILL.md
- npx --yes skills add ... install smoke for all 9 Sendmux skills