### PR TITLE
Add OpenClaw ClawHub publishing gate

### DIFF
--- a/.github/workflows/openclaw-clawhub.yml
+++ b/.github/workflows/openclaw-clawhub.yml
@@ -62,7 +62,7 @@ jobs:
 
   publish:
     name: Publish OpenClaw bundle
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
     needs: validate
     runs-on: ubuntu-latest
     environment: clawhub

--- a/.github/workflows/openclaw-clawhub.yml
+++ b/.github/workflows/openclaw-clawhub.yml
@@ -1,0 +1,98 @@
+name: OpenClaw ClawHub
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "openclaw.skills.json"
+      - "scripts/build-openclaw-bundle.mjs"
+      - "scripts/check-openclaw-bundle.mjs"
+      - ".github/workflows/openclaw-clawhub.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "skills/**"
+      - "openclaw.skills.json"
+      - "scripts/build-openclaw-bundle.mjs"
+      - "scripts/check-openclaw-bundle.mjs"
+      - ".github/workflows/openclaw-clawhub.yml"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish generated Sendmux skills to ClawHub"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openclaw-clawhub-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Build and dry-run OpenClaw bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Generate OpenClaw bundle
+        run: node scripts/build-openclaw-bundle.mjs
+
+      - name: Check OpenClaw bundle
+        run: node scripts/check-openclaw-bundle.mjs
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
+
+      - name: Dry-run ClawHub publish
+        run: |
+          for skill_path in dist/clawhub/skills/*; do
+            clawhub skill publish "$skill_path" --owner sendmux.ai --dry-run --json
+          done
+
+  publish:
+    name: Publish OpenClaw bundle
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: clawhub
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Generate OpenClaw bundle
+        run: node scripts/build-openclaw-bundle.mjs
+
+      - name: Check OpenClaw bundle
+        run: node scripts/check-openclaw-bundle.mjs
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
+
+      - name: Authenticate ClawHub CLI
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          test -n "$CLAWHUB_TOKEN"
+          clawhub login --token "$CLAWHUB_TOKEN"
+
+      - name: Publish ClawHub skills
+        run: |
+          for skill_path in dist/clawhub/skills/*; do
+            clawhub skill publish "$skill_path" --owner sendmux.ai --json
+          done

--- a/openclaw.skills.json
+++ b/openclaw.skills.json
@@ -1,0 +1,117 @@
+{
+  "owner": "sendmux.ai",
+  "outputRoot": "dist/clawhub/skills",
+  "homepage": "https://github.com/Sendmux/skills",
+  "version": "1.0.0",
+  "releaseTags": ["latest"],
+  "manualListing": {
+    "license": "MIT-0",
+    "categories": ["Communication", "Developer Tools", "Automation"],
+    "topics": [
+      "sendmux",
+      "email",
+      "agent-inbox",
+      "mcp",
+      "cli",
+      "inbound-email",
+      "outbound-email",
+      "routing"
+    ]
+  },
+  "envVars": {
+    "SENDMUX_API_KEY": "Optional Sendmux API key or scoped agent token used by CLI, SDK, HTTP, or MCP examples.",
+    "SENDMUX_ROOT_KEY": "Optional Sendmux root key for account-level Management API setup.",
+    "SENDMUX_MBX_KEY": "Optional Sendmux mailbox key for Mailbox and send-capable mailbox workflows.",
+    "SENDMUX_PROFILE": "Optional Sendmux CLI profile name.",
+    "SENDMUX_BASE_URL": "Optional Sendmux API base URL override for CLI examples.",
+    "SENDMUX_MCP_SURFACES": "Optional comma-separated surfaces for the combined Sendmux MCP server.",
+    "SENDMUX_MAILBOX_API_KEY": "Optional mailbox key for the Mailbox surface in the combined MCP server.",
+    "SENDMUX_MANAGEMENT_API_KEY": "Optional root key for the Management surface in the combined MCP server.",
+    "SENDMUX_SENDING_API_KEY": "Optional send-capable mailbox key or owner-approved agent token for the Sending MCP surface.",
+    "SENDMUX_MCP_HTTP_BEARER_TOKEN": "Optional bearer token expected by the local HTTP MCP server."
+  },
+  "skills": {
+    "sendmux-attachments": {
+      "displayName": "Sendmux Attachments",
+      "description": "Move email attachments through Sendmux without putting file bytes in model context, using file paths, presigned URLs, CLI, SDKs, or MCP.",
+      "categories": ["Communication", "Developer Tools", "Automation"],
+      "topics": ["sendmux", "email", "attachments", "mcp", "cli", "file-upload"]
+    },
+    "sendmux-cli": {
+      "displayName": "Sendmux CLI",
+      "description": "Use the Sendmux CLI for terminal-driven Management, Mailbox, and Sending workflows with JSON output and scoped credentials.",
+      "categories": ["Developer Tools", "Communication", "Automation"],
+      "topics": ["sendmux", "cli", "email", "developer-tools", "automation"],
+      "install": [
+        {
+          "kind": "node",
+          "package": "@sendmux/cli",
+          "bins": ["sendmux"]
+        }
+      ]
+    },
+    "sendmux-email-for-agents": {
+      "displayName": "Sendmux Agent Inbox",
+      "description": "Give OpenClaw agents a Sendmux inbox to receive, triage, route, reply to, and send email with owner approval and scoped credentials.",
+      "categories": ["Communication", "Automation", "Developer Tools"],
+      "topics": [
+        "sendmux",
+        "agent-inbox",
+        "email",
+        "inbound-email",
+        "outbound-email",
+        "routing",
+        "human-approval",
+        "mcp"
+      ]
+    },
+    "sendmux-getting-started": {
+      "displayName": "Sendmux Getting Started",
+      "description": "Set up Sendmux for agents, choose MCP, CLI, SDK, or HTTP, validate scoped credentials, and make the first harmless call.",
+      "categories": ["Developer Tools", "Communication", "Automation"],
+      "topics": ["sendmux", "getting-started", "email", "agent-auth", "mcp", "cli"]
+    },
+    "sendmux-mailbox-agent": {
+      "displayName": "Sendmux Mailbox Agent",
+      "description": "Let an OpenClaw agent read, search, count, sync, triage, file, delete, thread, and reply from one Sendmux mailbox efficiently.",
+      "categories": ["Communication", "Automation", "Developer Tools"],
+      "topics": ["sendmux", "mailbox", "agent-inbox", "email", "triage", "sync"]
+    },
+    "sendmux-management": {
+      "displayName": "Sendmux Management",
+      "description": "Manage Sendmux domains, mailboxes, mailbox keys, sending accounts, webhooks, logs, billing, and account-level setup.",
+      "categories": ["Developer Tools", "Automation", "Communication"],
+      "topics": ["sendmux", "management", "domains", "mailboxes", "webhooks", "email"]
+    },
+    "sendmux-mcp-setup": {
+      "displayName": "Sendmux MCP Setup",
+      "description": "Connect OpenClaw and other agent clients to hosted or local Sendmux MCP servers for mailbox, sending, and management tools.",
+      "categories": ["Developer Tools", "Automation", "Communication"],
+      "topics": ["sendmux", "mcp", "openclaw", "email", "agent-tools", "setup"],
+      "install": [
+        {
+          "kind": "uv",
+          "package": "sendmux-mcp",
+          "bins": [
+            "sendmux-mcp",
+            "sendmux-mcp-mailbox",
+            "sendmux-mcp-management",
+            "sendmux-mcp-sending"
+          ]
+        }
+      ]
+    },
+    "sendmux-send-email": {
+      "displayName": "Sendmux Send Email",
+      "description": "Send one or many emails through Sendmux using approved mailbox or agent credentials, idempotency keys, attachments, MCP, CLI, SDKs, or HTTP.",
+      "categories": ["Communication", "Automation", "Developer Tools"],
+      "topics": ["sendmux", "email", "outbound-email", "sending", "attachments", "mcp"]
+    },
+    "sendmux-token-efficient-usage": {
+      "displayName": "Sendmux Token Efficient Usage",
+      "description": "Choose low-token Sendmux calls across MCP, CLI, SDKs, and HTTP by using snippets, counts, batches, deltas, cursors, ETags, and idempotency.",
+      "categories": ["Developer Tools", "Automation", "Communication"],
+      "topics": ["sendmux", "token-efficiency", "mcp", "cli", "batching", "email"]
+    }
+  }
+}

--- a/scripts/build-openclaw-bundle.mjs
+++ b/scripts/build-openclaw-bundle.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const configPath = path.join(repoRoot, "openclaw.skills.json");
+const sourceRoot = path.join(repoRoot, "skills");
+
+const config = JSON.parse(readFileSync(configPath, "utf8"));
+const outputRoot = path.resolve(repoRoot, config.outputRoot);
+
+function assertSafeOutputRoot() {
+  const relative = path.relative(repoRoot, outputRoot);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to write outside repository: ${outputRoot}`);
+  }
+  if (!relative.startsWith("dist/clawhub/skills")) {
+    throw new Error(`Refusing to clean unexpected output root: ${relative}`);
+  }
+}
+
+function listSkillSlugs(root) {
+  return readdirSync(root)
+    .filter((entry) => {
+      const entryPath = path.join(root, entry);
+      return statSync(entryPath).isDirectory();
+    })
+    .filter((entry) => existsSync(path.join(root, entry, "SKILL.md")))
+    .sort();
+}
+
+function parseSourceSkill(slug) {
+  const filePath = path.join(sourceRoot, slug, "SKILL.md");
+  const text = readFileSync(filePath, "utf8");
+  const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+
+  if (!match) {
+    throw new Error(`${slug}: missing source frontmatter`);
+  }
+
+  const frontmatter = match[1];
+  const body = match[2].replace(/^\n+/, "");
+  const name = readYamlScalar(frontmatter, "name");
+  const description = readYamlScalar(frontmatter, "description");
+
+  if (name !== slug) {
+    throw new Error(`${slug}: source name ${name} does not match folder name`);
+  }
+
+  return { body, description, name };
+}
+
+function readYamlScalar(frontmatter, key) {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  if (!match) return null;
+
+  const raw = match[1].trim();
+  if (raw.startsWith('"') && raw.endsWith('"')) {
+    return JSON.parse(raw);
+  }
+  if (raw.startsWith("'") && raw.endsWith("'")) {
+    return raw.slice(1, -1).replace(/''/g, "'");
+  }
+  return raw;
+}
+
+function referencedSendmuxEnvVars(text) {
+  return [...new Set(text.match(/\bSENDMUX_[A-Z0-9_]+\b/g) ?? [])].sort();
+}
+
+function openclawNote() {
+  return [
+    "## ClawHub account note",
+    "",
+    "This ClawHub skill connects OpenClaw agents to Sendmux. Some workflows require a Sendmux account and an appropriate Sendmux API key or agent token. Sendmux account usage is external to ClawHub; do not ask users to paste secrets into chat.",
+  ].join("\n");
+}
+
+function addOpenclawNote(body) {
+  const trimmed = body.replace(/^\n+/, "");
+  const lines = trimmed.split("\n");
+
+  if (lines[0]?.startsWith("# ")) {
+    const rest = lines.slice(1).join("\n").replace(/^\n+/, "");
+    return `${lines[0]}\n\n${openclawNote()}\n\n${rest}`.replace(/\n+$/, "\n");
+  }
+
+  return `${openclawNote()}\n\n${trimmed}`.replace(/\n+$/, "\n");
+}
+
+function yamlScalar(value) {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (value === null) return "null";
+  throw new Error(`Unsupported YAML scalar: ${value}`);
+}
+
+function isScalar(value) {
+  return value === null || ["string", "number", "boolean"].includes(typeof value);
+}
+
+function toYaml(value, indent = 0) {
+  const pad = " ".repeat(indent);
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (isScalar(item)) return `${pad}- ${yamlScalar(item)}`;
+
+        const entries = Object.entries(item);
+        if (entries.length === 0) return `${pad}- {}`;
+
+        const [firstKey, firstValue] = entries[0];
+        const firstLine = isScalar(firstValue)
+          ? `${pad}- ${firstKey}: ${yamlScalar(firstValue)}`
+          : `${pad}- ${firstKey}:\n${toYaml(firstValue, indent + 2)}`;
+        const rest = entries
+          .slice(1)
+          .map(([key, nestedValue]) =>
+            isScalar(nestedValue)
+              ? `${" ".repeat(indent + 2)}${key}: ${yamlScalar(nestedValue)}`
+              : `${" ".repeat(indent + 2)}${key}:\n${toYaml(nestedValue, indent + 4)}`,
+          );
+
+        return [firstLine, ...rest].join("\n");
+      })
+      .join("\n");
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value)
+      .map(([key, nestedValue]) =>
+        isScalar(nestedValue)
+          ? `${pad}${key}: ${yamlScalar(nestedValue)}`
+          : `${pad}${key}:\n${toYaml(nestedValue, indent + 2)}`,
+      )
+      .join("\n");
+  }
+
+  return `${pad}${yamlScalar(value)}`;
+}
+
+function buildFrontmatter(slug, source) {
+  const skillConfig = config.skills[slug];
+  const bodyEnvVars = referencedSendmuxEnvVars(source.body);
+  const envVars = bodyEnvVars.map((name) => {
+    const description = config.envVars[name];
+    if (!description) {
+      throw new Error(`${slug}: missing description for ${name} in openclaw.skills.json`);
+    }
+    return { name, required: false, description };
+  });
+
+  const openclaw = {
+    skillKey: slug,
+    homepage: config.homepage,
+  };
+
+  if (bodyEnvVars.includes("SENDMUX_API_KEY")) {
+    openclaw.primaryEnv = "SENDMUX_API_KEY";
+  }
+  if (envVars.length > 0) {
+    openclaw.envVars = envVars;
+  }
+  if (skillConfig.install) {
+    openclaw.install = skillConfig.install;
+  }
+
+  return {
+    name: slug,
+    description: skillConfig.description ?? source.description,
+    version: config.version,
+    metadata: {
+      openclaw,
+    },
+  };
+}
+
+function verifyConfigCoverage(sourceSlugs) {
+  const configSlugs = Object.keys(config.skills).sort();
+  const missing = sourceSlugs.filter((slug) => !configSlugs.includes(slug));
+  const extra = configSlugs.filter((slug) => !sourceSlugs.includes(slug));
+
+  if (missing.length > 0) {
+    throw new Error(`Missing OpenClaw config for: ${missing.join(", ")}`);
+  }
+  if (extra.length > 0) {
+    throw new Error(`OpenClaw config references unknown skills: ${extra.join(", ")}`);
+  }
+}
+
+assertSafeOutputRoot();
+
+const sourceSlugs = listSkillSlugs(sourceRoot);
+verifyConfigCoverage(sourceSlugs);
+
+rmSync(outputRoot, { recursive: true, force: true });
+mkdirSync(outputRoot, { recursive: true });
+
+for (const slug of sourceSlugs) {
+  const source = parseSourceSkill(slug);
+  const frontmatter = buildFrontmatter(slug, source);
+  const skillDir = path.join(outputRoot, slug);
+  const outputPath = path.join(skillDir, "SKILL.md");
+  const output = `---\n${toYaml(frontmatter)}\n---\n\n${addOpenclawNote(source.body)}`;
+
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(outputPath, output, "utf8");
+}
+
+console.log(`Generated ${sourceSlugs.length} OpenClaw skills in ${path.relative(repoRoot, outputRoot)}.`);

--- a/scripts/check-openclaw-bundle.mjs
+++ b/scripts/check-openclaw-bundle.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const configPath = path.join(repoRoot, "openclaw.skills.json");
+const sourceRoot = path.join(repoRoot, "skills");
+
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function readText(filePath) {
+  if (!existsSync(filePath)) {
+    fail(`Missing file: ${filePath}`);
+    return "";
+  }
+  return readFileSync(filePath, "utf8");
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(readText(filePath));
+  } catch (error) {
+    fail(`Invalid JSON in ${filePath}: ${error.message}`);
+    return null;
+  }
+}
+
+function listSkillSlugs(root) {
+  if (!existsSync(root)) return [];
+  return readdirSync(root)
+    .filter((entry) => {
+      const entryPath = path.join(root, entry);
+      return statSync(entryPath).isDirectory();
+    })
+    .filter((entry) => existsSync(path.join(root, entry, "SKILL.md")))
+    .sort();
+}
+
+function extractFrontmatter(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) return null;
+  return match[1];
+}
+
+function declaredEnvVars(frontmatter) {
+  const vars = new Set();
+  for (const match of frontmatter.matchAll(/(?:^|\n)\s*(?:-\s*)?name:\s*"?([A-Z][A-Z0-9_]+)"?/g)) {
+    vars.add(match[1]);
+  }
+  for (const match of frontmatter.matchAll(/(?:^|\n)\s*primaryEnv:\s*"?([A-Z][A-Z0-9_]+)"?/g)) {
+    vars.add(match[1]);
+  }
+  for (const match of frontmatter.matchAll(/(?:^|\n)\s*-\s*"?([A-Z][A-Z0-9_]+)"?/g)) {
+    vars.add(match[1]);
+  }
+  return vars;
+}
+
+function referencedSendmuxEnvVars(text) {
+  return [...new Set(text.match(/\bSENDMUX_[A-Z0-9_]+\b/g) ?? [])].sort();
+}
+
+function walkFiles(root) {
+  if (!existsSync(root)) return [];
+  const files = [];
+  for (const entry of readdirSync(root)) {
+    const entryPath = path.join(root, entry);
+    const stat = statSync(entryPath);
+    if (stat.isDirectory()) {
+      files.push(...walkFiles(entryPath));
+    } else {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
+}
+
+if (!existsSync(configPath)) {
+  fail("Missing openclaw.skills.json");
+}
+
+const config = existsSync(configPath) ? readJson(configPath) : null;
+const outputRoot = path.resolve(repoRoot, config?.outputRoot ?? "dist/clawhub/skills");
+const sourceSlugs = listSkillSlugs(sourceRoot);
+const outputSlugs = listSkillSlugs(outputRoot);
+const configSlugs = Object.keys(config?.skills ?? {}).sort();
+
+if (sourceSlugs.length === 0) {
+  fail("No source skills found under skills/*/SKILL.md");
+}
+
+const expectedSkillCount = sourceSlugs.length;
+if (outputSlugs.length !== expectedSkillCount) {
+  fail(`Generated skill count mismatch: expected ${expectedSkillCount}, found ${outputSlugs.length}`);
+}
+
+for (const slug of sourceSlugs) {
+  if (!configSlugs.includes(slug)) {
+    fail(`Missing OpenClaw config for ${slug}`);
+  }
+  if (!outputSlugs.includes(slug)) {
+    fail(`Missing generated OpenClaw skill for ${slug}`);
+  }
+}
+
+for (const slug of configSlugs) {
+  if (!sourceSlugs.includes(slug)) {
+    fail(`OpenClaw config references unknown skill ${slug}`);
+  }
+}
+
+for (const filePath of walkFiles(outputRoot)) {
+  const relativePath = path.relative(outputRoot, filePath);
+  if (!/^[^/]+\/SKILL\.md$/.test(relativePath)) {
+    fail(`Generated bundle should contain only <skill>/SKILL.md, found ${relativePath}`);
+  }
+}
+
+for (const slug of outputSlugs) {
+  const skillPath = path.join(outputRoot, slug, "SKILL.md");
+  const text = readText(skillPath);
+  const frontmatter = extractFrontmatter(text);
+
+  if (!frontmatter) {
+    fail(`${slug}: missing YAML frontmatter`);
+    continue;
+  }
+
+  for (const field of ["name", "description", "version"]) {
+    if (!new RegExp(`(?:^|\\n)${field}:\\s+`).test(frontmatter)) {
+      fail(`${slug}: missing frontmatter field ${field}`);
+    }
+  }
+
+  if (!/(?:^|\n)metadata:\n\s+openclaw:/.test(frontmatter)) {
+    fail(`${slug}: missing metadata.openclaw`);
+  }
+
+  if (/(?:^|\n)license:\s*/.test(frontmatter)) {
+    fail(`${slug}: generated frontmatter must not include a license field`);
+  }
+
+  if (/Apache-2\.0/.test(text)) {
+    fail(`${slug}: generated bundle must not contain Apache-2.0`);
+  }
+
+  if (!/This ClawHub skill connects OpenClaw agents to Sendmux\./.test(text)) {
+    fail(`${slug}: missing ClawHub external account note`);
+  }
+
+  const declared = declaredEnvVars(frontmatter);
+  for (const envName of referencedSendmuxEnvVars(text)) {
+    if (!declared.has(envName)) {
+      fail(`${slug}: references ${envName} but does not declare it in metadata.openclaw`);
+    }
+  }
+}
+
+const agentInboxPath = path.join(outputRoot, "sendmux-email-for-agents", "SKILL.md");
+if (existsSync(agentInboxPath)) {
+  const text = readText(agentInboxPath);
+  for (const term of ["inbox", "receive", "send", "route"]) {
+    if (!new RegExp(term, "i").test(text)) {
+      fail(`sendmux-email-for-agents should frame Sendmux as an agent inbox that can ${term}`);
+    }
+  }
+}
+
+if (!sourceSlugs.includes("sendmux-attachments")) {
+  fail("Source skills must include sendmux-attachments before publishing to OpenClaw");
+}
+
+if (!outputSlugs.includes("sendmux-attachments")) {
+  fail("Generated OpenClaw bundle must include sendmux-attachments");
+}
+
+if (failures.length > 0) {
+  console.error("OpenClaw bundle check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`OpenClaw bundle check passed for ${outputSlugs.length} skills.`);


### PR DESCRIPTION
## Summary
- add OpenClaw ClawHub metadata config for all Sendmux skills
- generate MIT-0-compatible ClawHub bundles under ignored dist/clawhub/skills
- add PR dry-run and main-push/manual publish workflow for ClawHub

## Verification
- node --check scripts/build-openclaw-bundle.mjs
- node --check scripts/check-openclaw-bundle.mjs
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/openclaw-clawhub.yml'); puts 'workflow yaml parsed'"
- node -e "JSON.parse(require('node:fs').readFileSync('openclaw.skills.json','utf8')); console.log('openclaw.skills.json parsed')"
- node scripts/build-openclaw-bundle.mjs
- node scripts/check-openclaw-bundle.mjs
- npx --yes clawhub skill publish dist/clawhub/skills/<skill> --owner sendmux.ai --dry-run --json for all 9 generated skills