### PR TITLE
chore: release skills bundle 1.1.0

### DIFF
--- a/openclaw.skills.json
+++ b/openclaw.skills.json
@@ -2,7 +2,7 @@
   "owner": "sendmux.ai",
   "outputRoot": "dist/clawhub/skills",
   "homepage": "https://github.com/Sendmux/skills",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "releaseTags": ["latest"],
   "manualListing": {
     "license": "MIT-0",


### PR DESCRIPTION
## Summary\n- bump the OpenClaw skills bundle version to 1.1.0 for the recent attachment workflow skill release\n\n## Verification\n- node --test scripts/publish-openclaw-bundle.test.mjs\n- node scripts/build-openclaw-bundle.mjs && node scripts/check-openclaw-bundle.mjs\n- fetched public OpenAPI specs and ran scripts/check-skill-drift.mjs\n- git diff --check\n\n## Notes\n- No CLAUDE.md or AGENTS.md changes are included.