### PR TITLE
Teach Sendmux skills agent-friendly attachment workflows

### DIFF
--- a/scripts/check-skill-drift.mjs
+++ b/scripts/check-skill-drift.mjs
@@ -308,6 +308,33 @@ function assertSkillCorpusTokens() {
   }
 }
 
+function assertAttachmentSkillContentLengthGuidance() {
+  const skillPath = fullPath(
+    skillsRoot,
+    "skills/sendmux-attachments/SKILL.md",
+  );
+  const skillText = readText(skillPath);
+  const directUploadExample = skillText.match(
+    /curl -X POST "https:\/\/smtp\.sendmux\.ai\/api\/v1\/emails\/attachments[\s\S]*?--data-binary @\.\/report\.pdf/,
+  )?.[0];
+
+  if (!directUploadExample) {
+    fail("sendmux-attachments missing Direct HTTP Sending direct upload curl example");
+  } else if (!/Content-Length/.test(directUploadExample)) {
+    fail(
+      "sendmux-attachments Direct HTTP Sending upload example must include Content-Length",
+    );
+  }
+
+  if (
+    !/direct Sending API binary uploads require exact `Content-Length`/i.test(
+      skillText,
+    )
+  ) {
+    fail("sendmux-attachments missing direct Sending Content-Length guidance");
+  }
+}
+
 function assertCliPackage() {
   const cliPackagePath = fullPath(sdkRoot, "packages/ts/cli/package.json");
   const cliPackage = readJson(cliPackagePath);
@@ -431,6 +458,7 @@ assertOfficialSendmuxEnvOnly();
 assertSdkPackages();
 assertSkillsCatalogue();
 assertSkillCorpusTokens();
+assertAttachmentSkillContentLengthGuidance();
 
 if (failures.length > 0) {
   console.error("Sendmux skill drift check failed:");

--- a/scripts/check-skill-drift.mjs
+++ b/scripts/check-skill-drift.mjs
@@ -32,6 +32,10 @@ const expectedSkills = [
 ];
 
 const requiredSendingPaths = [
+  ["post", "/emails/attachment-uploads"],
+  ["put", "/emails/attachment-uploads/{upload_id}"],
+  ["post", "/emails/attachments"],
+  ["get", "/emails/attachments/{attachment_id}"],
   ["post", "/emails/send"],
   ["post", "/emails/send/batch"],
 ];
@@ -59,6 +63,7 @@ const requiredMcpTools = [
   "mailbox_get_changes",
   "mailbox_send_message",
   "mailbox_get_attachment",
+  "mailbox_read_attachment",
   "mailbox_upload_attachment",
   "mailbox_wait_for_message",
   "management_create_domain",
@@ -66,8 +71,11 @@ const requiredMcpTools = [
   "management_create_mailbox_key",
   "management_get_spend_summary",
   "management_create_webhook",
+  "sending_create_attachment_upload",
+  "sending_get_attachment",
   "sending_send_email",
   "sending_send_email_batch",
+  "sending_upload_attachment",
 ];
 
 const requiredMcpEnv = [
@@ -136,9 +144,15 @@ const requiredCorpusTokens = [
   ["attachment skill", /sendmux-attachments/],
   ["mailbox upload attachment MCP tool", /mailbox_upload_attachment/],
   ["mailbox attachment metadata MCP tool", /mailbox_get_attachment/],
+  ["mailbox read attachment MCP tool", /mailbox_read_attachment/],
   ["management create domain MCP tool", /management_create_domain/],
   ["management create mailbox MCP tool", /management_create_mailbox/],
   ["management create mailbox key MCP tool", /management_create_mailbox_key/],
+  ["sending upload attachment MCP tool", /sending_upload_attachment/],
+  ["sending create attachment upload MCP tool", /sending_create_attachment_upload/],
+  ["sending get attachment MCP tool", /sending_get_attachment/],
+  ["sending attachment upload endpoint", /\/emails\/attachments/],
+  ["sending delegated upload endpoint", /\/emails\/attachment-uploads/],
 ];
 
 const failures = [];

--- a/skills/sendmux-attachments/SKILL.md
+++ b/skills/sendmux-attachments/SKILL.md
@@ -30,6 +30,7 @@ Approximate base64 cost: 25 KB becomes about 11K generated tokens; 1 MB is impra
 - The later presigned `PUT` has no `Authorization` header, but it only works with the unguessable short-lived signed URL and exact headers returned by Sendmux.
 - Do not invent file-type allow-lists. Set the best `Content-Type`; let Sendmux return the real validation error if a file is rejected.
 - For presigned `PUT`, send the exact `Content-Type` and `Content-Length` returned with the URL.
+- Direct Sending API binary uploads require exact `Content-Length`. CLI, SDK, and MCP file helpers calculate it for you.
 - Do not try to bypass upload size caps. For mailbox uploads, split or externally host files over 7,500,000 bytes.
 - For MCP reads, call `mailbox_read_attachment` first. It returns inline text for text-like attachments and a link for binary or oversized files.
 - For direct downloads, use the `download_url` in attachment metadata promptly. If it expires, fetch the message or attachment metadata again.
@@ -197,9 +198,12 @@ Override MIME type with `--content-type` only when inference is wrong.
 Sending API direct upload with an API key:
 
 ```bash
+SIZE_BYTES="$(wc -c < ./report.pdf | tr -d '[:space:]')"
+
 curl -X POST "https://smtp.sendmux.ai/api/v1/emails/attachments?filename=report.pdf&content_type=application/pdf" \
   -H "Authorization: Bearer $SENDMUX_MBX_KEY" \
   -H "Content-Type: application/pdf" \
+  -H "Content-Length: $SIZE_BYTES" \
   --data-binary @./report.pdf
 ```
 

--- a/skills/sendmux-attachments/SKILL.md
+++ b/skills/sendmux-attachments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sendmux-attachments
-description: Use Sendmux attachment workflows without wasting model context on base64. Use when uploading, downloading, reading, forwarding, or sending email attachments through Sendmux MCP, CLI, SDKs, or direct HTTP, especially when choosing file_path vs presigned upload URL vs inline base64, fetching short-lived download_url links, or attaching local files to outbound mail.
+description: Use Sendmux attachment workflows without wasting model context on base64. Use when uploading, downloading, reading, forwarding, or sending email attachments through Sendmux MCP, CLI, SDKs, or direct HTTP, especially when choosing file_path vs presigned upload URL vs inline base64, reading inbound attachments with mailbox_read_attachment, fetching short-lived download_url links, or attaching local files to outbound mail.
 license: Apache-2.0
 metadata:
   author: sendmux
@@ -17,9 +17,9 @@ Do not pipe real files through model context as base64 unless the file is tiny a
 
 | Mode | Use when | Token cost | Limit |
 | --- | --- | ---: | --- |
-| Local `file_path` | Local stdio MCP can read the user-shared file root. | tiny | Mailbox cap: 7,500,000 bytes per attachment. |
-| Presigned upload URL | Hosted MCP, shell-capable agents, or large local files. | tiny | Mailbox cap: 7,500,000 bytes; exact size is signed. |
-| CLI `--attach` / SDK file helpers | Terminal or application code can read the file. | tiny | Mailbox cap for mailbox sends; Sending API request limit for Sending sends. |
+| Local `file_path` | Local stdio MCP can read the user-shared file root. | tiny | Mailbox cap: 7,500,000 bytes; Sending upload cap: 18 MiB. |
+| Presigned upload URL | Hosted MCP, shell-capable agents, or large local files. | tiny | Mailbox cap: 7,500,000 bytes; Sending upload cap: 18 MiB; exact size is signed. |
+| CLI `--attach` / SDK file helpers | Terminal or application code can read the file. | tiny | Mailbox cap for mailbox sends; Sending upload cap: 18 MiB and final message cap: 25 MB. |
 | Inline base64 | Small generated text/files only. | high | MCP inline cap is 32 KiB decoded. |
 
 Approximate base64 cost: 25 KB becomes about 11K generated tokens; 1 MB is impractical. A file path is usually under 100 tokens.
@@ -31,9 +31,13 @@ Approximate base64 cost: 25 KB becomes about 11K generated tokens; 1 MB is impra
 - Do not invent file-type allow-lists. Set the best `Content-Type`; let Sendmux return the real validation error if a file is rejected.
 - For presigned `PUT`, send the exact `Content-Type` and `Content-Length` returned with the URL.
 - Do not try to bypass upload size caps. For mailbox uploads, split or externally host files over 7,500,000 bytes.
-- For downloads, use the `download_url` in attachment metadata promptly. If it expires, fetch the message or attachment metadata again.
+- For MCP reads, call `mailbox_read_attachment` first. It returns inline text for text-like attachments and a link for binary or oversized files.
+- For direct downloads, use the `download_url` in attachment metadata promptly. If it expires, fetch the message or attachment metadata again.
+- Sending API sends use `attachment_id` refs returned by Sending upload endpoints. Mailbox sends use `blob_id` refs returned by mailbox upload endpoints. Do not mix them.
 
 ## MCP
+
+### Mailbox upload and read
 
 Use `mailbox_upload_attachment` before `mailbox_send_message`.
 
@@ -83,7 +87,55 @@ Use the returned `blob_id` in `mailbox_send_message`:
 
 For tiny generated content only, use `content_base64`. If the tool rejects size, switch to `file_path`, presigned upload, CLI, or SDK file helpers.
 
-To read inbound attachments, call `mailbox_get_attachment` or fetch message metadata, then fetch `download_url` promptly. Do not construct attachment URLs manually.
+To read inbound attachments, call `mailbox_read_attachment` with `message_id` and `attachment_id`.
+
+```text
+mailbox_read_attachment
+message_id: msg_...
+attachment_id: att_...
+```
+
+Use returned `text` directly for text-like files. If the tool returns `resource_link` / `download_url`, fetch the link promptly outside model context. Use `mailbox_get_attachment` only when metadata is enough or you need to refresh an expired link. Do not construct attachment URLs manually.
+
+### Sending API upload
+
+Local stdio, cheapest path:
+
+```text
+sending_upload_attachment
+filename: report.pdf
+content_type: application/pdf
+file_path: /absolute/path/report.pdf
+```
+
+Use the returned `attachment_id` in `sending_send_email` or `sending_send_email_batch`:
+
+```json
+{
+  "attachments": [{ "attachment_id": "att_..." }]
+}
+```
+
+Hosted or shell-capable path:
+
+```text
+sending_create_attachment_upload
+filename: report.pdf
+content_type: application/pdf
+size_bytes: 5242880
+```
+
+Then `PUT` the file bytes to the returned `upload_url` with the returned headers, including `X-Sendmux-Upload-Token`; do not add a Sendmux API key:
+
+```bash
+curl -X PUT "$UPLOAD_URL" \
+  -H "X-Sendmux-Upload-Token: $UPLOAD_TOKEN" \
+  -H "Content-Type: application/pdf" \
+  -H "Content-Length: 5242880" \
+  --data-binary @./report.pdf
+```
+
+Use the `attachment_id` from the upload response in the send request. Use `sending_get_attachment` only for metadata checks.
 
 ## CLI
 
@@ -111,6 +163,16 @@ SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:send \
   --json
 ```
 
+Upload a Sending attachment first, then send by `attachment_id`:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:upload-attachment \
+  --body-file ./report.pdf \
+  --query filename=report.pdf \
+  --query content_type=application/pdf \
+  --json
+```
+
 Presigned mailbox upload from a local file:
 
 ```bash
@@ -130,6 +192,28 @@ SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:create-attachment-upload \
 
 Override MIME type with `--content-type` only when inference is wrong.
 
+## Direct HTTP
+
+Sending API direct upload with an API key:
+
+```bash
+curl -X POST "https://smtp.sendmux.ai/api/v1/emails/attachments?filename=report.pdf&content_type=application/pdf" \
+  -H "Authorization: Bearer $SENDMUX_MBX_KEY" \
+  -H "Content-Type: application/pdf" \
+  --data-binary @./report.pdf
+```
+
+Sending API delegated upload:
+
+```bash
+curl -X POST "https://smtp.sendmux.ai/api/v1/emails/attachment-uploads" \
+  -H "Authorization: Bearer $SENDMUX_MBX_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"filename":"report.pdf","content_type":"application/pdf","size_bytes":5242880}'
+```
+
+Then `PUT` to the returned `upload_url` with returned headers and no Sendmux API key. Use `GET /emails/attachments/{attachment_id}` only for metadata checks.
+
 ## TypeScript
 
 Node file helpers live under Node subpaths so browser bundles stay clean.
@@ -138,7 +222,10 @@ Mailbox:
 
 ```ts
 import { createMailboxClient } from "@sendmux/mailbox";
-import { sendMailboxMessageWithFiles } from "@sendmux/mailbox/node";
+import {
+  readMailboxTextAttachment,
+  sendMailboxMessageWithFiles,
+} from "@sendmux/mailbox/node";
 
 const client = createMailboxClient({ apiKey: process.env.SENDMUX_API_KEY! });
 
@@ -151,6 +238,12 @@ await sendMailboxMessageWithFiles({
     subject: "Report",
     text_body: "Attached.",
   },
+});
+
+const text = await readMailboxTextAttachment({
+  client,
+  messageId: "msg_...",
+  attachmentId: "att_...",
 });
 ```
 
@@ -182,7 +275,7 @@ The combined package also exposes `@sendmux/sdk/node`.
 Mailbox:
 
 ```python
-from sendmux_mailbox import create_mailbox_client, send_mailbox_message_with_files
+from sendmux_mailbox import create_mailbox_client, read_mailbox_text_attachment, send_mailbox_message_with_files
 
 client = create_mailbox_client(api_key=api_key)
 
@@ -195,6 +288,12 @@ send_mailbox_message_with_files(
         "text_body": "Attached.",
     },
     idempotency_key=idempotency_key,
+)
+
+text = read_mailbox_text_attachment(
+    client,
+    message_id="msg_...",
+    attachment_id="att_...",
 )
 ```
 

--- a/skills/sendmux-attachments/evals/evals.json
+++ b/skills/sendmux-attachments/evals/evals.json
@@ -65,6 +65,20 @@
         "The output uses resource_link or download_url only as fallback for binary or oversized files.",
         "The output does not construct attachment URLs manually."
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Show direct HTTP curl to upload ./report.pdf to the Sendmux Sending API as an attachment before sending it.",
+      "expected_output": "The answer computes the file byte length locally, sends POST /emails/attachments with Authorization, Content-Type, exact Content-Length, and --data-binary, avoids base64, then uses the returned attachment_id in the send request.",
+      "files": [],
+      "expectations": [
+        "The output computes the file byte length locally.",
+        "The output calls POST /emails/attachments.",
+        "The output includes Authorization and Content-Type headers.",
+        "The output includes exact Content-Length for the file bytes.",
+        "The output avoids manual base64 encoding.",
+        "The output sends with the returned attachment_id."
+      ]
     }
   ]
 }

--- a/skills/sendmux-attachments/evals/evals.json
+++ b/skills/sendmux-attachments/evals/evals.json
@@ -38,6 +38,33 @@
         "The output passes a file path.",
         "The output avoids manual base64 encoding."
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "A hosted MCP agent with shell access needs to attach ./report.pdf through the Sendmux Sending API without base64. What flow should it use?",
+      "expected_output": "The answer calls sending_create_attachment_upload with filename, content_type, and size_bytes, PUTs the file bytes to the returned upload_url with returned headers including X-Sendmux-Upload-Token and no Sendmux API key, then passes the returned attachment_id in sending_send_email attachments[].",
+      "files": [],
+      "expectations": [
+        "The output chooses sending_create_attachment_upload.",
+        "The output includes filename, content_type, and size_bytes.",
+        "The output uses PUT to the returned upload_url.",
+        "The output uses X-Sendmux-Upload-Token or returned headers.",
+        "The output says not to include a Sendmux API key on the PUT.",
+        "The output sends with an attachment_id reference."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "An MCP agent found a markdown attachment in a Sendmux mailbox message. How should it read it?",
+      "expected_output": "The answer calls mailbox_read_attachment with message_id and attachment_id, uses returned text for text-like attachments, falls back to resource_link or download_url for binary or oversized files, and does not construct attachment URLs manually.",
+      "files": [],
+      "expectations": [
+        "The output chooses mailbox_read_attachment.",
+        "The output passes message_id and attachment_id.",
+        "The output uses returned text for text-like attachments.",
+        "The output uses resource_link or download_url only as fallback for binary or oversized files.",
+        "The output does not construct attachment URLs manually."
+      ]
     }
   ]
 }

--- a/skills/sendmux-attachments/evals/trigger-evals.json
+++ b/skills/sendmux-attachments/evals/trigger-evals.json
@@ -8,7 +8,11 @@
     "should_trigger": true
   },
   {
-    "query": "Fetch a Sendmux attachment download_url from mailbox metadata.",
+    "query": "A hosted MCP agent needs to attach a PDF through the Sendmux Sending API without base64.",
+    "should_trigger": true
+  },
+  {
+    "query": "Read a markdown attachment from a Sendmux mailbox message.",
     "should_trigger": true
   },
   {

--- a/skills/sendmux-cli/SKILL.md
+++ b/skills/sendmux-cli/SKILL.md
@@ -76,7 +76,7 @@ The CLI exposes generated operation commands:
 | ---------- | ----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Management |    53 | `management:domains:list`, `management:create-domain`, `management:create-mailbox`, `management:get-spend-summary`, `management:create-webhook`            |
 | Mailbox    |    41 | `mailbox:search-message-snippets`, `mailbox:batch-get-messages`, `mailbox:query-message-changes`, `mailbox:send-message`, `mailbox:list-granted-mailboxes` |
-| Sending    |     3 | `sending:get-open-api-spec`, `sending:send`, `sending:send:batch`                                                                                          |
+| Sending    |     7 | `sending:get-open-api-spec`, `sending:send`, `sending:send:batch`, `sending:upload-attachment`, `sending:create-attachment-upload`, `sending:complete-attachment-upload`, `sending:get-attachment` |
 | Profiles   |     3 | `profiles:list`, `profiles:set`, `profiles:show`                                                                                                           |
 
 Use command-level help to discover accepted path, query, header, and body fields:
@@ -85,6 +85,7 @@ Use command-level help to discover accepted path, query, header, and body fields
 sendmux management:create-domain --help
 sendmux mailbox:search-message-snippets --help
 sendmux sending:send:batch --help
+sendmux sending:upload-attachment --help
 ```
 
 ## Operation flags
@@ -99,8 +100,8 @@ Operation commands share these flags:
 | `--body`              | Inline JSON request body, or text bytes for byte-oriented operations.      |
 | `--body-file`         | Read a JSON request body or byte payload from a file.                      |
 | `--attach`            | Attach a local file to supported send commands. Repeat for multiple files. |
-| `--file`              | Read a local file for attachment upload commands.                          |
-| `--via-presigned`     | Upload a `--file` through a short-lived signed URL instead of API bytes.   |
+| `--file`              | Read a local file for mailbox attachment upload convenience commands.       |
+| `--via-presigned`     | Upload a mailbox `--file` through a short-lived signed URL instead of API bytes. |
 | `--content-type`      | Override inferred MIME type for `--attach` or `--file`.                    |
 | `--path name=value`   | Path parameters. Repeat for multiple path params.                          |
 | `--query name=value`  | Query parameters. Repeat for filters and pagination.                       |
@@ -168,6 +169,30 @@ sendmux sending:send:batch \
   --profile sending \
   --idempotency-key "$IDEMPOTENCY_KEY" \
   --body-file ./messages.json \
+  --json
+```
+
+Send through the Sending API with a local attachment:
+
+```bash
+sendmux sending:send \
+  --profile sending \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --attach ./report.pdf \
+  --body '{"from":{"email":"sender@example.com"},"to":{"email":"user@example.com"},"subject":"Report","html_body":"<p>Attached.</p>"}' \
+  --json
+```
+
+`sending:send --attach` uploads the file first and injects an `attachment_id` reference; it does not place base64 in the send body.
+
+Upload a Sending attachment separately:
+
+```bash
+sendmux sending:upload-attachment \
+  --profile sending \
+  --body-file ./report.pdf \
+  --query filename=report.pdf \
+  --query content_type=application/pdf \
   --json
 ```
 

--- a/skills/sendmux-email-for-agents/SKILL.md
+++ b/skills/sendmux-email-for-agents/SKILL.md
@@ -53,7 +53,7 @@ For self-registration without a human-created key, use agent access instead:
 - Keep the `identity_assertion` or pre-claim `smx_agent_*` token available until the owner invite returns `202`. If both are lost before the invite succeeds, register a fresh identity and invite immediately.
 - Do not poll the claim-token grant before the owner invite returns `202`; after `202`, polling with `claim_token` is the wait-for-approval path. `claim_token` cannot create the owner invite.
 - Do not send email until the user has supplied or confirmed the recipient, subject, body, and attachments.
-- Do not place real attachment bytes or long base64 in chat. Use `sendmux-attachments` so local files move by path, presigned URL, CLI, or SDK helper. Mailbox upload modes cap each attachment at 7,500,000 bytes.
+- Do not place real attachment bytes or long base64 in chat. Use `sendmux-attachments` so local files move by path, presigned URL, CLI, or SDK helper. Mailbox upload modes cap each attachment at 7,500,000 bytes; Sending uploads cap each file at 18 MiB and send by `attachment_id`.
 - Treat "draft for approval" as a draft. Ask for explicit approval before calling `mailbox_send_message`, `sending_send_email`, or `sending_send_email_batch`.
 - Use separate scopes: `smx_root_*` for provisioning/admin, send-capable `smx_mbx_*` keys or owner-approved Sending-resource `smx_agent_*` tokens for Sending, `smx_mbx_*` keys for normal Mailbox runtime, and `smx_agent_*` only for the scopes it was issued with.
 - Do not use a root key inside an agent that only needs mailbox read/send work.

--- a/skills/sendmux-mcp-setup/SKILL.md
+++ b/skills/sendmux-mcp-setup/SKILL.md
@@ -51,15 +51,16 @@ Console scripts:
 | ---------- | ----------------------------------------------------------------------- | ---------: | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Mailbox    | `smx_mbx_` or scoped `smx_agent_`                                       |         24 | `mailbox_list_granted_mailboxes`, `mailbox_search_message_snippets`, `mailbox_get_attachment`, `mailbox_upload_attachment`, `mailbox_wait_for_message` |
 | Management | `smx_root_`                                                             |         20 | `management_create_domain`, `management_create_mailbox`, `management_create_mailbox_key`, `management_get_spend_summary`, `management_create_webhook` |
-| Sending    | Send-capable `smx_mbx_` or owner-approved Sending-resource `smx_agent_` |          2 | `sending_send_email`, `sending_send_email_batch`                                                                                                      |
+| Sending    | Send-capable `smx_mbx_` or owner-approved Sending-resource `smx_agent_` |          5 | `sending_send_email`, `sending_send_email_batch`, `sending_upload_attachment`, `sending_create_attachment_upload`, `sending_get_attachment`            |
 
 For multi-mailbox grants, call `mailbox_list_granted_mailboxes` first and pass the returned `mailbox_id` to mailbox tools when targeting a mailbox.
 
-Attachment upload mode depends on transport:
+Attachment upload mode depends on transport and send surface:
 
 - Local stdio can use `mailbox_upload_attachment` with `file_path` when the file is inside a client-shared filesystem root.
 - Hosted MCP cannot read local paths. Use `presign_upload_url=true`, upload with shell `curl`, then send with the returned `blob_id`.
-- Use `content_base64` only for tiny generated files. Mailbox `file_path` and presigned upload modes cap each attachment at 7,500,000 bytes; MCP inline base64 caps at 32 KiB decoded. See `sendmux-attachments`.
+- Sending MCP uses `sending_upload_attachment` with `file_path` on local stdio, or `sending_create_attachment_upload` plus an external `PUT` for hosted/shell-capable agents, then sends with `attachment_id`.
+- Use `content_base64` only for tiny generated files. Mailbox upload modes cap each attachment at 7,500,000 bytes; Sending upload caps each file at 18 MiB; MCP inline base64 caps at 32 KiB decoded. See `sendmux-attachments`.
 
 ## Local Servers
 
@@ -377,7 +378,7 @@ After adding the server:
 2. Confirm the visible tools match the selected surfaces:
    - Mailbox-only: no `management_*` or `sending_*` tools.
    - Management-only: no `mailbox_*` or `sending_*` tools.
-   - Sending-only: only `sending_send_email` and `sending_send_email_batch`.
+   - Sending-only: `sending_send_email`, `sending_send_email_batch`, and Sending attachment tools.
 3. Run one harmless read tool:
    - Mailbox: `mailbox_get_me` or `mailbox_get_session`.
    - Management: `management_list_domains` with a small limit.

--- a/skills/sendmux-send-email/SKILL.md
+++ b/skills/sendmux-send-email/SKILL.md
@@ -27,6 +27,7 @@ Use this skill when the user is ready to send outbound email through Sendmux or 
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | One outbound email                        | `POST /emails/send`, MCP `sending_send_email`, CLI `sending:send`, or SDK `sendingSendEmail`.                                          |
 | More than one independent outbound email  | Batch by default: `POST /emails/send/batch`, MCP `sending_send_email_batch`, CLI `sending:send:batch`, or SDK `sendingSendEmailBatch`. |
+| Sending API attachment file               | Upload first with `sending_upload_attachment`, `sending_create_attachment_upload`, CLI `--attach`, or SDK file helpers; send by `attachment_id`. |
 | Replying while working inside one mailbox | Use mailbox send from `sendmux-mailbox-agent` when the workflow is mailbox-centred.                                                    |
 | Existing app only supports SMTP           | Use SMTP only because the existing tool requires it. For new agent or app integrations, prefer the HTTP Sending API.                   |
 
@@ -55,9 +56,9 @@ Useful optional fields:
 - `reply_to`: one address object.
 - `return_path`: envelope sender for bounce handling.
 - `custom_headers`: custom `X-*` headers.
-- `attachments`: up to 10 items, each with `filename` and base64 `content`; optional `type`; `encoding` is `base64`; total request body must stay within the Sending API limit.
+- `attachments`: up to 10 items. Prefer uploaded refs `{ "attachment_id": "att_..." }`. Inline compatibility form uses `filename` plus base64 `content`, optional `type`, and `encoding: "base64"`.
 
-For real local files, do not ask the model to produce base64. Route attachment-heavy work to `sendmux-attachments`; use CLI `--attach`, SDK file helpers, or mailbox upload-to-`blob_id` first. Mailbox upload-to-`blob_id` caps each attachment at 7,500,000 bytes.
+For real local files, do not ask the model to produce base64. Route attachment-heavy work to `sendmux-attachments`; use CLI `--attach`, SDK file helpers, `sending_upload_attachment`, or delegated `sending_create_attachment_upload`, then pass `attachment_id` refs. Sending uploads cap each file at 18 MiB and the final sent message at 25 MB. Mailbox `blob_id` refs are for mailbox sends, not Sending API sends.
 
 Batch send body:
 
@@ -94,6 +95,9 @@ Use MCP when the user's agent already has the Sending server connected:
 
 - One message: `sending_send_email`.
 - Multiple messages: `sending_send_email_batch`.
+- Local file upload before send: `sending_upload_attachment` with `file_path`.
+- Hosted or shell-capable upload before send: `sending_create_attachment_upload`, then `PUT` bytes to the returned URL with the returned headers and no Sendmux API key.
+- Metadata check for a temporary uploaded attachment: `sending_get_attachment`.
 
 Include an idempotency key when the client exposes the header parameter. If the MCP client does not expose headers clearly, use CLI, SDK, or direct HTTP for retry-sensitive sends. For attachments through MCP, use `sendmux-attachments` so the agent chooses `file_path`, presigned upload, or tiny inline base64 correctly.
 
@@ -123,7 +127,7 @@ SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:send:batch \
   --json
 ```
 
-Use `--attach ./file.pdf` for local files. Use `--body-file` for larger JSON payloads or already-prepared Sending API attachment objects.
+Use `--attach ./file.pdf` for local files; the CLI uploads bytes first and injects `attachment_id` refs before sending. Use `--body-file` for larger JSON payloads or already-prepared Sending API attachment objects.
 
 ## TypeScript SDK
 

--- a/skills/sendmux-send-email/evals/evals.json
+++ b/skills/sendmux-send-email/evals/evals.json
@@ -17,14 +17,15 @@
     {
       "id": 1,
       "prompt": "Show a Sendmux CLI example for sending one email with an attachment and safe retry behaviour.",
-      "expected_output": "The answer uses sendmux sending:send, a send-capable smx_mbx_ key or owner-approved Sending-resource smx_agent_ token, Idempotency-Key, --body or --body-file, and attachment fields filename/content with base64 content.",
+      "expected_output": "The answer uses sendmux sending:send with --attach for the local file, a send-capable smx_mbx_ key or owner-approved Sending-resource smx_agent_ token, Idempotency-Key, --body or --body-file, and says the CLI uploads bytes first and injects an attachment_id ref rather than base64.",
       "files": [],
       "expectations": [
         "The output uses the CLI command sendmux sending:send.",
         "The output uses a send-capable smx_mbx_ key or owner-approved Sending-resource smx_agent_ token.",
         "The output includes an Idempotency-Key or --idempotency-key.",
-        "The output uses attachment fields filename and content.",
-        "The output states attachment content is base64."
+        "The output uses --attach for the local file.",
+        "The output says the CLI uploads bytes first and uses an attachment_id reference.",
+        "The output avoids manual base64 encoding."
       ]
     },
     {

--- a/skills/sendmux-token-efficient-usage/SKILL.md
+++ b/skills/sendmux-token-efficient-usage/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to choose the lowest-cost Sendmux route that still answers the ta
 - Use scoped `smx_agent_*` only for the calls its scopes and resource allow. Pre-claim agent tokens cannot send.
 - Use `smx_root_*` for Management calls.
 - Do not default to MCP for every task. MCP is best when the required tool is curated; CLI and SDK cover broader surfaces.
-- Do not pipe real attachments through model context as base64. Route attachment transfer to `sendmux-attachments`; prefer `file_path`, presigned URLs, CLI `--attach`, or SDK file helpers. Mailbox uploads cap each attachment at 7,500,000 bytes; MCP inline base64 caps at 32 KiB decoded.
+- Do not pipe real attachments through model context as base64. Route attachment transfer to `sendmux-attachments`; prefer `file_path`, presigned URLs, CLI `--attach`, or SDK file helpers. Mailbox uploads cap each attachment at 7,500,000 bytes; Sending uploads cap each file at 18 MiB; MCP inline base64 caps at 32 KiB decoded.
 - Do not read full mailbox bodies, every message, or every log row unless the user asks for full content and narrower calls cannot answer.
 
 ## Surface choice
@@ -37,7 +37,7 @@ Use this skill to choose the lowest-cost Sendmux route that still answers the ta
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | Send one outbound email         | `sending_send_email`, CLI `sending:send`, SDK `sendingSendEmail`; include `Idempotency-Key`.                                           |
 | Send multiple outbound emails   | `sending_send_email_batch`, CLI `sending:send:batch`, SDK `sendingSendEmailBatch`; do not loop single sends.                           |
-| Send or read attachments        | `sendmux-attachments`; use `file_path`, presigned upload/download URLs, CLI `--attach`, or SDK file helpers instead of inline base64.   |
+| Send or read attachments        | `sendmux-attachments`; use `file_path`, presigned upload/download URLs, CLI `--attach`, SDK file helpers, `blob_id` for mailbox sends, and `attachment_id` for Sending sends instead of inline base64. |
 | Count matching mailbox messages | `mailbox_count_messages`, CLI `mailbox:count-messages`, SDK `mailboxCountMessages`.                                                    |
 | Search mailbox text             | `mailbox_search_message_snippets`, CLI `mailbox:search-message-snippets`, SDK `mailboxSearchMessageSnippets`; then fetch selected IDs. |
 | Read several known messages     | `mailbox_batch_get_messages`, CLI `mailbox:batch-get-messages`, SDK `mailboxBatchGetMessages`.                                         |


### PR DESCRIPTION
## Summary
- Update sendmux-attachments skill guidance for exact Content-Length on direct Sending binary uploads
- Add an eval that checks direct HTTP upload examples compute and send byte length
- Extend skill-drift checks so docs/SDK Content-Length guidance cannot drift silently

## Related
- Docs PR: https://github.com/Sendmux/docs/pull/20
- SDK PR: https://github.com/Sendmux/sendmux-sdk/pull/96

## Verification
- SENDMUX_DOCS=/Users/rj/Desktop/GIT-REPOS/sendmux-docs-ai-attachment-reading SENDMUX_SDK=/Users/rj/Desktop/GIT-REPOS/sendmux-sdk-ai-attachment-reading node scripts/check-skill-drift.mjs
- node scripts/check-openclaw-bundle.mjs
- python3 /Users/rj/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/sendmux-attachments