### PR TITLE
chore: release skills bundle 1.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,7 @@ skills/
 Canonical GitHub repo: `Sendmux/skills`, with `main` as the default branch. Keep public examples on `npx skills add Sendmux/skills`.
 
 Do not publish a new release, register/update skills.sh metadata, or publish docs without explicit approval.
+
+Skill content changes merged to `main` are not complete until a new public GitHub release is created and verified. Bump `openclaw.skills.json` to the next SemVer version, tag/release that exact version, verify `gh release view`, and verify the relevant publishing/sync workflows before reporting the skill work complete.
+
+For multiline GitHub release notes, use `gh release ... --notes-file -` or a real notes file; never pass escaped `\n` strings. Verify the saved body has real Markdown line breaks before reporting success.

--- a/openclaw.skills.json
+++ b/openclaw.skills.json
@@ -2,7 +2,7 @@
   "owner": "sendmux.ai",
   "outputRoot": "dist/clawhub/skills",
   "homepage": "https://github.com/Sendmux/skills",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "releaseTags": ["latest"],
   "manualListing": {
     "license": "MIT-0",


### PR DESCRIPTION
## Summary
- bump OpenClaw skills bundle version to 1.2.0 for the merged attachment workflow skill updates
- add a release-completion guardrail to the public agent guide

## Verification
- node scripts/check-skill-drift.mjs
- node --test scripts/publish-openclaw-bundle.test.mjs
- node scripts/build-openclaw-bundle.mjs
- node scripts/check-openclaw-bundle.mjs
- git diff --check

major: no