### PR TITLE
Release skills 1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "sendmux",
       "source": "./plugins/sendmux",
       "description": "Official Sendmux Agent Skills for email, mailbox, MCP, CLI, and SDK workflows.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Sendmux"
       },

--- a/openclaw.skills.json
+++ b/openclaw.skills.json
@@ -2,7 +2,7 @@
   "owner": "sendmux.ai",
   "outputRoot": "dist/clawhub/skills",
   "homepage": "https://github.com/Sendmux/skills",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "releaseTags": ["latest"],
   "manualListing": {
     "license": "MIT-0",

--- a/plugins/sendmux/.claude-plugin/plugin.json
+++ b/plugins/sendmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sendmux",
   "displayName": "Sendmux",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Official Sendmux Agent Skills for email, mailbox, MCP, CLI, and SDK workflows.",
   "author": {
     "name": "Sendmux",

--- a/plugins/sendmux/.codex-plugin/plugin.json
+++ b/plugins/sendmux/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sendmux",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Official Sendmux Agent Skills for email, mailbox, MCP, CLI, and SDK workflows.",
   "author": {
     "name": "Sendmux",


### PR DESCRIPTION
## Summary
- Bump Sendmux Agent Skills release metadata to 1.3.0.
- Regenerate Claude and Codex plugin manifests from the canonical skills manifest.

## Verification
- `node --test scripts/build-plugin-bundles.test.mjs scripts/publish-openclaw-bundle.test.mjs`
- `node scripts/check-plugin-bundles.mjs`
- `node scripts/check-openclaw-bundle.mjs`
- `node scripts/check-skill-drift.mjs`
- `python3 /Users/rj/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/sendmux`
- `claude plugin validate . --strict`
